### PR TITLE
Proposal: extension to route hooks

### DIFF
--- a/src/createRoute.ts
+++ b/src/createRoute.ts
@@ -96,6 +96,10 @@ export interface Route<PP extends Parameters> {
 	 */
 	exec(request: Request<PP>): void;
 
+	enter(request: Request<PP>): void;
+
+	exit(): void;
+
 	/**
 	 * If specified, causes the route to be selected if there are no nested routes that match the remainder of
 	 * the dispatched path. When the route is executed, this handler is called rather than `exec()`.
@@ -177,6 +181,10 @@ export interface RouteOptions<PP> {
 	 */
 	exec?(request: Request<PP>): void;
 
+	enter?(request: Request<PP>): void;
+
+	exit?(): void;
+
 	/**
 	 * If specified, causes the route to be selected if there are no nested routes that match the remainder of
 	 * the dispatched path. When the route is executed, this handler is called rather than `exec()`.
@@ -229,6 +237,10 @@ const createRoute: RouteFactory = compose<Route<Parameters>, RouteOptions<Parame
 			this.routes.push(routes);
 		}
 	},
+
+	enter (request: Request<Parameters>) {},
+
+	exit () {},
 
 	exec (request: Request<Parameters>) {},
 
@@ -315,11 +327,20 @@ const createRoute: RouteFactory = compose<Route<Parameters>, RouteOptions<Parame
 
 		return [];
 	}
-}, (instance, { exec, fallback, guard, index, params, path, trailingSlashMustMatch = true } = {}) => {
+}, (instance, {
+		exec,
+		fallback,
+		guard,
+		index,
+		params,
+		path,
+		enter,
+		exit,
+		trailingSlashMustMatch = true
+	} = {}) => {
 	if (path && /#/.test(path)) {
 		throw new TypeError('Path must not contain \'#\'');
 	}
-
 	instance.path = deconstructPath(path || '/');
 	instance.routes = [];
 	instance.trailingSlashMustMatch = trailingSlashMustMatch;
@@ -336,6 +357,15 @@ const createRoute: RouteFactory = compose<Route<Parameters>, RouteOptions<Parame
 	if (index) {
 		instance.index = index;
 	}
+
+	if (enter) {
+		instance.enter = enter;
+	}
+
+	if (exit) {
+		instance.exit = exit;
+	}
+
 	if (params) {
 		const { parameters, searchParameters } = instance.path;
 		if (parameters.length === 0 && searchParameters.length === 0) {

--- a/src/createRoute.ts
+++ b/src/createRoute.ts
@@ -96,9 +96,9 @@ export interface Route<PP extends Parameters> {
 	 */
 	exec(request: Request<PP>): void;
 
-	enter(request: Request<PP>): void;
+	added(request: Request<PP>): void;
 
-	exit(): void;
+	removed(): void;
 
 	/**
 	 * If specified, causes the route to be selected if there are no nested routes that match the remainder of
@@ -181,9 +181,9 @@ export interface RouteOptions<PP> {
 	 */
 	exec?(request: Request<PP>): void;
 
-	enter?(request: Request<PP>): void;
+	added?(request: Request<PP>): void;
 
-	exit?(): void;
+	removed?(): void;
 
 	/**
 	 * If specified, causes the route to be selected if there are no nested routes that match the remainder of
@@ -238,9 +238,9 @@ const createRoute: RouteFactory = compose<Route<Parameters>, RouteOptions<Parame
 		}
 	},
 
-	enter (request: Request<Parameters>) {},
+	added (request: Request<Parameters>) {},
 
-	exit () {},
+	removed () {},
 
 	exec (request: Request<Parameters>) {},
 
@@ -334,8 +334,8 @@ const createRoute: RouteFactory = compose<Route<Parameters>, RouteOptions<Parame
 		index,
 		params,
 		path,
-		enter,
-		exit,
+		added,
+		removed,
 		trailingSlashMustMatch = true
 	} = {}) => {
 	if (path && /#/.test(path)) {
@@ -358,12 +358,12 @@ const createRoute: RouteFactory = compose<Route<Parameters>, RouteOptions<Parame
 		instance.index = index;
 	}
 
-	if (enter) {
-		instance.enter = enter;
+	if (added) {
+		instance.added = added;
 	}
 
-	if (exit) {
-		instance.exit = exit;
+	if (removed) {
+		instance.removed = removed;
 	}
 
 	if (params) {

--- a/src/createRouter.ts
+++ b/src/createRouter.ts
@@ -57,8 +57,6 @@ export interface RouterMixin {
 	 */
 	routes?: Route<Parameters>[];
 
-	prevHierarchy?: Selection[];
-
 	/**
 	 * Append one or more routes.
 	 * @param routes A single route or an array containing 0 or more routes.

--- a/src/createRouter.ts
+++ b/src/createRouter.ts
@@ -180,7 +180,7 @@ const createRouter: RouterFactory = compose<RouterMixin, RouterOptions>({
 
 						this.prevHierarchy = hierarchy;
 
-						exits.map(({ route }) => route.exit());
+						exits.reverse().map(({ route }) => route.exit());
 
 						if (hierarchy.length === 0) {
 							return false;

--- a/src/createRouter.ts
+++ b/src/createRouter.ts
@@ -175,18 +175,18 @@ const createRouter: RouterFactory = compose<RouterMixin, RouterOptions>({
 					const dispatched = (<Router> this).routes.some(route => {
 						const hierarchy = route.select(context, segments, trailingSlash, searchParams);
 
-						const exits = diffHeirarchy(this.prevHierarchy, hierarchy);
-						const enters = diffHeirarchy(hierarchy, this.prevHierarchy);
+						const removed = diffHeirarchy(this.prevHierarchy, hierarchy);
+						const added = diffHeirarchy(hierarchy, this.prevHierarchy);
 
 						this.prevHierarchy = hierarchy;
 
-						exits.reverse().map(({ route }) => route.exit());
+						removed.reverse().map(({ route }) => route.removed());
 
 						if (hierarchy.length === 0) {
 							return false;
 						}
 
-						enters.map(({ route, params }) => route.enter({ context, params }));
+						added.map(({ route, params }) => route.added({ context, params }));
 
 						for (const { handler, route, params } of hierarchy) {
 							switch (handler) {

--- a/tests/unit/createRouter.ts
+++ b/tests/unit/createRouter.ts
@@ -2,7 +2,7 @@ import Promise from 'dojo-core/Promise';
 import { suite, test } from 'intern!tdd';
 import * as assert from 'intern/chai!assert';
 
-import createRoute from '../../src/createRoute';
+import createRoute, { Route } from '../../src/createRoute';
 import createRouter from '../../src/createRouter';
 import { DefaultParameters, Context as C, Request, Parameters } from '../../src/interfaces';
 
@@ -340,17 +340,17 @@ suite('createRouter', () => {
 		}));
 	});
 
-	test('enter called for new routes in the hierarchy', () => {
-			let entered: any[] = [];
-			function enter() {
-				entered.push(this);
+	test('added called for new routes in the hierarchy', () => {
+			let adds: Route<Parameters>[] = [];
+			function added() {
+				adds.push(this);
 			}
 
 			const router = createRouter();
-			const foo = createRoute({ path: '/foo', enter });
-			const bar = createRoute({ path: 'bar', enter });
-			const baz = createRoute({ path: 'baz', enter });
-			const qux = createRoute({ path: 'qux', enter });
+			const foo = createRoute({ path: '/foo', added });
+			const bar = createRoute({ path: 'bar', added });
+			const baz = createRoute({ path: 'baz', added });
+			const qux = createRoute({ path: 'qux', added });
 
 			foo.append(bar);
 			bar.append(baz);
@@ -358,31 +358,31 @@ suite('createRouter', () => {
 			router.append(foo);
 
 			return router.dispatch({}, 'foo/bar/baz').then(() => {
-				assert.equal(foo, entered[0]);
-				assert.equal(bar, entered[1]);
-				assert.equal(baz, entered[2]);
-				assert.equal(3, entered.length);
+				assert.equal(foo, adds[0]);
+				assert.equal(bar, adds[1]);
+				assert.equal(baz, adds[2]);
+				assert.equal(3, adds.length);
 
-				entered = [];
+				adds = [];
 
 				return router.dispatch({}, 'foo/bar/qux').then(() => {
-					assert.equal(qux, entered[0]);
-					assert.equal(1, entered.length);
+					assert.equal(qux, adds[0]);
+					assert.equal(1, adds.length);
 				});
 			});
 	});
 
-	test('exit called for routes no longer in the hierarchy', () => {
-			let exited: any[] = [];
-			function exit() {
-				exited.push(this);
+	test('removed called for routes no longer in the hierarchy', () => {
+			let removes: Route<Parameters>[] = [];
+			function removed() {
+				removes.push(this);
 			}
 
 			const router = createRouter();
-			const foo = createRoute({ path: '/foo', exit });
-			const bar = createRoute({ path: 'bar', exit });
-			const baz = createRoute({ path: 'baz', exit });
-			const qux = createRoute({ path: 'qux', exit });
+			const foo = createRoute({ path: '/foo', removed });
+			const bar = createRoute({ path: 'bar', removed });
+			const baz = createRoute({ path: 'baz', removed });
+			const qux = createRoute({ path: 'qux', removed });
 
 			foo.append(bar);
 			foo.append(qux);
@@ -390,11 +390,11 @@ suite('createRouter', () => {
 			router.append(foo);
 
 			return router.dispatch({}, 'foo/bar/baz').then(() => {
-				assert.equal(0, exited.length);
+				assert.equal(0, removes.length);
 				return router.dispatch({}, 'foo/qux').then(() => {
-					assert.equal(baz, exited[0]);
-					assert.equal(bar, exited[1]);
-					assert.equal(2, exited.length);
+					assert.equal(baz, removes[0]);
+					assert.equal(bar, removes[1]);
+					assert.equal(2, removes.length);
 				});
 			});
 	});

--- a/tests/unit/createRouter.ts
+++ b/tests/unit/createRouter.ts
@@ -392,8 +392,8 @@ suite('createRouter', () => {
 			return router.dispatch({}, 'foo/bar/baz').then(() => {
 				assert.equal(0, exited.length);
 				return router.dispatch({}, 'foo/qux').then(() => {
-					assert.equal(bar, exited[0]);
-					assert.equal(baz, exited[1]);
+					assert.equal(baz, exited[0]);
+					assert.equal(bar, exited[1]);
 					assert.equal(2, exited.length);
 				});
 			});

--- a/tests/unit/createRouter.ts
+++ b/tests/unit/createRouter.ts
@@ -385,15 +385,16 @@ suite('createRouter', () => {
 			const qux = createRoute({ path: 'qux', exit });
 
 			foo.append(bar);
+			foo.append(qux);
 			bar.append(baz);
-			bar.append(qux);
 			router.append(foo);
 
 			return router.dispatch({}, 'foo/bar/baz').then(() => {
 				assert.equal(0, exited.length);
-				return router.dispatch({}, 'foo/bar/qux').then(() => {
-					assert.equal(baz, exited[0]);
-					assert.equal(1, exited.length);
+				return router.dispatch({}, 'foo/qux').then(() => {
+					assert.equal(bar, exited[0]);
+					assert.equal(baz, exited[1]);
+					assert.equal(2, exited.length);
 				});
 			});
 	});


### PR DESCRIPTION
### Background

Currently the only lifecycle hook we have is `exec`. `exec` is simple in behaviour, regardless of previous route selections it will always be called (pre-requisite that it passes the matching conditions obviously). 

The below example has routes of the following, parent to child:  

```
a -> b -> c -> d1 
            -> d2
```

Given the following dispatches:

```
dispatch 1: a/b/c/d1
```

`a`, `b`, `c` and `d1`'s `exec`'s will each be called.

```
dispatch 2: a/b/c/d2
```

`a`, `b`, `c` and `d2`'s `exec`'s will each be called.

Now lets imagine what an average developer might trigger in their `exec` for `a`:

``` javascript
const action = createAction({
    do() {
        return doSomethingReallyExpensive()
            .then(doSomethingElseReallyExpensive)      
    }
});

createRoute({
    path: 'a',
    exec() {
       action.do();
    }
});
```

Given that we have a stack of selected of routes, it seems surprising that given `a` hasn't changed that the `exec` would still be called, which results in the expensive action being performed twice. Obviously avoiding the expensive action is possible elsewhere other than the router (e.g we just be reactive all the way down), but I believe we could add more specific hooks to the router to cater for this.
### Proposed hooks to add

**`added`**

The `added` hook  is only called when the route is added to the hierarchy. Given the above example again:  

```
dispatch 1:  a/b/c/d1
```

`a`, `b`, `c` and `d1`'s `added`'s will each be called.

```
dispatch 2: a/b/c/d2
```

only `d2`'s `added`'s will only be called.

note: the added hooks are called in order from top to bottom. they are called after the removed cycle, but before the exec cycle.

**`removed`**

The `removed` hook  is only called when the route is removed from the hierarchy. Given the above example again: 

```
dispatch 1: a/b/c/d1
```

no `removed`'s called.

```
dispatch 2: a/b/c/d2
```

only  `d1`'s `removed` will be called.

note: the removed hooks are called in order from bottom to top. they are called before the added cycle.

Thoughts invited! the PR is not complete, but I think it shows that it would be fairly trivial to add. We might want to think more about a `changed` lifecycle hook also for routes that have a param that changed.
