### PR TITLE
Implement observeHistory

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,14 @@ const history = createMemoryHistory();
 
 The `createMemoryHistory()` factory accepts a `path` option. It defaults to the empty string.
 
+#### Wiring History manager changes to Router dispatches
+
+Although you can manually wire a History manager `change` event to a `Router#dispatch()`, a utility function `Router#observeHistory()` will take care of the wiring for you. It takes a History manager, a Context and whether it should fire an initial dispatch.  An example of using it with a `StateHistory` manager:
+
+```ts
+router.observeHistory(createStateHistory(), { 'some': 'context' }, true);
+```
+
 ## How do I use this package?
 
 TODO: Add appropriate usage and instruction guidelines

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "intern": "~3.2.1",
     "istanbul": "0.4.3",
     "remap-istanbul": ">=0.6.4",
+    "sinon": "1.14.1",
     "tslint": "^3.10.2",
     "typescript": "~1.8.10"
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "intern": "~3.2.1",
     "istanbul": "0.4.3",
     "remap-istanbul": ">=0.6.4",
-    "sinon": "1.14.1",
+    "sinon": "^1.17.4",
     "tslint": "^3.10.2",
     "typescript": "~1.8.10"
   }

--- a/src/createRouter.ts
+++ b/src/createRouter.ts
@@ -1,11 +1,14 @@
 import compose, { ComposeFactory } from 'dojo-compose/compose';
 import createEvented, { Evented, EventedOptions, EventedListener, TargettedEventObject } from 'dojo-compose/mixins/createEvented';
 import { Handle } from 'dojo-core/interfaces';
+import { pausable, PausableHandle } from 'dojo-core/on';
 import Promise from 'dojo-core/Promise';
 import Task from 'dojo-core/async/Task';
+import WeakMap from 'dojo-core/WeakMap';
 
 import { Route, Handler } from './createRoute';
 import { Context, Parameters, Request } from './interfaces';
+import { History, HistoryChangeEvent } from './history/interfaces';
 import { parse as parsePath } from './_path';
 
 /**
@@ -61,6 +64,14 @@ export interface RouterMixin {
 	append(routes: Route<Parameters> | Route<Parameters>[]): void;
 
 	/**
+	 * Observe History, auto-wires the History change event to dispatch
+	 * @param history A History manager.
+	 * @param context A context object that is provided when executing selected routes.
+	 * @param dispatchInitial Whether to immediately dispatch with the History's current value.
+	 */
+	observeHistory(history: History, context: Context, dispatchInitial: boolean): PausableHandle;
+
+	/**
 	 * Select and execute routes for a given path.
 	 * @param context A context object that is provided when executing selected routes.
 	 * @param path The path.
@@ -101,6 +112,14 @@ export interface RouterOptions extends EventedOptions {
 	fallback?(request: Request<any>): void;
 }
 
+interface HistoryManager {
+	history: History;
+
+	context: Context;
+
+	listener: PausableHandle;
+}
+
 export interface RouterFactory extends ComposeFactory<Router, RouterOptions> {
 	/**
 	 * Create a new instance of a Router.
@@ -109,7 +128,10 @@ export interface RouterFactory extends ComposeFactory<Router, RouterOptions> {
 	(options?: RouterOptions): Router;
 }
 
+const historyMap = new WeakMap<Router, HistoryManager>();
+
 const createRouter: RouterFactory = compose<RouterMixin, RouterOptions>({
+
 	append (routes: Route<Parameters> | Route<Parameters>[]) {
 		if (Array.isArray(routes)) {
 			for (const route of routes) {
@@ -118,6 +140,21 @@ const createRouter: RouterFactory = compose<RouterMixin, RouterOptions>({
 		}
 		else {
 			this.routes.push(routes);
+		}
+	},
+
+	observeHistory(history: History, context: Context, dispatchInitial: boolean): PausableHandle {
+		if (!historyMap.has(this)) {
+			const listener = pausable(history, 'change', (event: HistoryChangeEvent) => {
+				this.dispatch(context, event.value);
+			});
+			historyMap.set(this, { history, listener, context });
+			if (dispatchInitial) {
+				this.dispatch(context, history.current);
+			}
+			this.own(listener);
+			this.own(history);
+			return listener;
 		}
 	},
 

--- a/src/createRouter.ts
+++ b/src/createRouter.ts
@@ -143,19 +143,21 @@ const createRouter: RouterFactory = compose<RouterMixin, RouterOptions>({
 		}
 	},
 
-	observeHistory(history: History, context: Context, dispatchInitial: boolean): PausableHandle {
-		if (!historyMap.has(this)) {
-			const listener = pausable(history, 'change', (event: HistoryChangeEvent) => {
-				this.dispatch(context, event.value);
-			});
-			historyMap.set(this, { history, listener, context });
-			if (dispatchInitial) {
-				this.dispatch(context, history.current);
-			}
-			this.own(listener);
-			this.own(history);
-			return listener;
+	observeHistory(history: History, context: Context, dispatchInitial: boolean = false): PausableHandle {
+		const router: Router = this;
+		if (historyMap.has(router)) {
+			throw new Error('observeHistory can only be called once');
 		}
+		const listener = pausable(history, 'change', (event: HistoryChangeEvent) => {
+			router.dispatch(context, event.value);
+		});
+		historyMap.set(router, { history, listener, context });
+		if (dispatchInitial) {
+			router.dispatch(context, history.current);
+		}
+		router.own(listener);
+		router.own(history);
+		return listener;
 	},
 
 	dispatch (context: Context, path: string): Task<boolean> {

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -55,7 +55,8 @@ export const loaderOptions = {
 		{ name: 'tests', location: '_build/tests' },
 		{ name: 'dojo', location: 'node_modules/intern/browser_modules/dojo' },
 		{ name: 'dojo-compose', location: 'node_modules/dojo-compose/dist/umd' },
-		{ name: 'dojo-core', location: 'node_modules/dojo-core/dist/umd' }
+		{ name: 'dojo-core', location: 'node_modules/dojo-core/dist/umd' },
+		{ name: 'sinon', location: 'node_modules/sinon/pkg', main: 'sinon' }
 	]
 };
 

--- a/tests/unit/createRouter.ts
+++ b/tests/unit/createRouter.ts
@@ -1,9 +1,11 @@
 import Promise from 'dojo-core/Promise';
 import { suite, test } from 'intern!tdd';
 import * as assert from 'intern/chai!assert';
+import { stub } from 'sinon';
 
 import createRoute from '../../src/createRoute';
 import createRouter from '../../src/createRouter';
+import createMemoryHistory from '../../src/history/createMemoryHistory';
 import { DefaultParameters, Context as C, Request, Parameters } from '../../src/interfaces';
 
 interface R extends Request<Parameters> {};
@@ -423,5 +425,45 @@ suite('createRouter', () => {
 		}).then(d => {
 			assert.deepEqual(extracted, {});
 		});
+	});
+
+	test('#observeHistory wires dispatch to a history change event', () => {
+		const router = createRouter();
+		const dispatch = stub(router, 'dispatch');
+
+		const history = createMemoryHistory();
+		const context = { 'foo': 'bar' };
+
+		router.observeHistory(history, context, false);
+		history.set('/foo');
+		assert.isTrue(dispatch.calledWith(context, '/foo'));
+	});
+
+	test('#observeHistory returns a pausable handler', () => {
+		const router = createRouter();
+		const dispatch = stub(router, 'dispatch');
+
+		const history = createMemoryHistory();
+		const context = { 'foo': 'bar' };
+
+		const listener = router.observeHistory(history, context, false);
+		listener.pause();
+		history.set('/foo');
+		assert.isFalse(dispatch.called);
+
+		listener.resume();
+		history.set('/bar');
+		assert.isTrue(dispatch.calledWith(context, '/bar'));
+	});
+
+	test('#observeHistory can dispatch immediately', () => {
+		const router = createRouter();
+		const dispatch = stub(router, 'dispatch');
+
+		const history = createMemoryHistory({ path: '/foo' });
+		const context = { 'foo': 'bar' };
+
+		router.observeHistory(history, context, true);
+		assert.isTrue(dispatch.calledWith(context, '/foo'));
 	});
 });

--- a/tests/unit/createRouter.ts
+++ b/tests/unit/createRouter.ts
@@ -466,4 +466,17 @@ suite('createRouter', () => {
 		router.observeHistory(history, context, true);
 		assert.isTrue(dispatch.calledWith(context, '/foo'));
 	});
+
+	test('#observeHistory throws if already called', () => {
+		const router = createRouter();
+		const history = createMemoryHistory();
+
+		function observeHistory() {
+			router.observeHistory(history, {}, false);
+		};
+
+		observeHistory();
+
+		assert.throws(observeHistory, /observeHistory can only be called once/);
+	});
 });

--- a/typings.json
+++ b/typings.json
@@ -6,7 +6,8 @@
 	},
 	"devDependencies": {
 		"chai": "registry:npm/chai#3.5.0+20160415060238",
-		"glob": "registry:npm/glob#6.0.0+20160211003958"
+		"glob": "registry:npm/glob#6.0.0+20160211003958",
+		"sinon": "registry:npm/sinon#1.16.0+20160427193336"
 	},
 	"globalDevDependencies": {
 		"digdug": "github:dojo/typings/custom/digdug/digdug.d.ts#a62873258aa1deed48f9882c193c335436100d4b",


### PR DESCRIPTION
Refs https://github.com/dojo/routing/issues/18

 `observeHistory` removes the need for some of the manual wiring required when using a `History` in an application. It will automatically wire the `change` event to `dispatch`, providing any `context` passed in the `observeHistory` call. Optionally it also takes a `dispatchInitial` flag, which will immediately trigger a `dispatch` with whatever the History's `current` value is.
