### PR TITLE
Migration to TS2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .sublimets
 .tscache
+.tsconfig*.json
 *.js
 !/index.js
 *.js.map

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/dojo/routing.git"
   },
   "scripts": {
-    "prepublish": "grunt dist",
+    "prepublish": "grunt peerDepInstall dist",
     "test": "grunt test"
   },
   "typings": "./dist/umd/dojo-routing.d.ts",
@@ -47,7 +47,7 @@
     "istanbul": "0.4.3",
     "remap-istanbul": ">=0.6.4",
     "sinon": "^1.17.4",
-    "tslint": "^3.10.2",
-    "typescript": "~1.8.10"
+    "tslint": "next",
+    "typescript": "beta"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   },
   "typings": "./dist/umd/dojo-routing.d.ts",
   "peerDependencies": {
-    "dojo-compose": "^2.0.0-beta.7",
-    "dojo-core": "^2.0.0-alpha.9",
-    "dojo-has": "^2.0.0-alpha.1",
-    "dojo-shim": "^2.0.0-alpha.1"
+    "dojo-compose": "next",
+    "dojo-core": "next",
+    "dojo-has": "next",
+    "dojo-shim": "next"
   },
   "devDependencies": {
     "codecov.io": "0.1.6",

--- a/src/_path.ts
+++ b/src/_path.ts
@@ -26,7 +26,7 @@ export function parse (path: string): ParsedPath {
 	const tokens: string[] = path.split(/([/?#])/).filter(Boolean);
 
 	let pathnameTokens = tokens;
-	let searchParams: UrlSearchParams = null;
+	let searchParams: UrlSearchParams;
 
 	const searchStart = tokens.indexOf('?');
 	const hashStart = tokens.indexOf('#');

--- a/src/createRoute.ts
+++ b/src/createRoute.ts
@@ -249,7 +249,7 @@ const createRoute: RouteFactory = compose<Route<Parameters>, RouteOptions<Parame
 		// Only extract the search params defined in the route's path.
 		const knownSearchParams = (<DeconstructedPath> this.path).searchParameters.reduce((list, name) => {
 			const value = searchParams.getAll(name);
-			if (value !== null) {
+			if (value !== undefined) {
 				list[name] = value;
 			}
 			return list;
@@ -272,7 +272,7 @@ const createRoute: RouteFactory = compose<Route<Parameters>, RouteOptions<Parame
 		});
 		searchParameters.forEach(name => {
 			const value = searchParams.get(name);
-			if (value !== null) {
+			if (value !== undefined) {
 				params[name] = value;
 			}
 		});
@@ -315,7 +315,7 @@ const createRoute: RouteFactory = compose<Route<Parameters>, RouteOptions<Parame
 
 		return [];
 	}
-}, (instance, { exec, fallback, guard, index, params, path, trailingSlashMustMatch = true } = {}) => {
+}, (instance: Route<Parameters>, { exec, fallback, guard, index, params, path, trailingSlashMustMatch = true }: RouteOptions<Parameters> = {}) => {
 	if (path && /#/.test(path)) {
 		throw new TypeError('Path must not contain \'#\'');
 	}

--- a/src/createRouter.ts
+++ b/src/createRouter.ts
@@ -173,8 +173,8 @@ const createRouter: RouterFactory = compose<RouterMixin, RouterOptions>({
 			path,
 			cancel,
 			defer () {
-				let cancel: () => void;
-				let resume: () => void;
+				let cancel: () => void = () => {};
+				let resume: () => void = () => {};
 				// TODO: remove casting to void when dojo/core#156 is resolved
 				deferrals.push(new Promise<void>((resolve, reject) => {
 					cancel = reject;
@@ -202,7 +202,7 @@ const createRouter: RouterFactory = compose<RouterMixin, RouterOptions>({
 						return false;
 					}
 
-					const dispatched = (<Router> this).routes.some(route => {
+					const dispatched = this.routes.some((route: Route<Parameters>) => {
 						const hierarchy = route.select(context, segments, trailingSlash, searchParams);
 						if (hierarchy.length === 0) {
 							return false;
@@ -214,10 +214,14 @@ const createRouter: RouterFactory = compose<RouterMixin, RouterOptions>({
 									route.exec({ context, params });
 									break;
 								case Handler.Fallback:
-									route.fallback({ context, params });
+									if (route.fallback) {
+										route.fallback({ context, params });
+									}
 									break;
 								case Handler.Index:
-									route.index({ context, params });
+									if (route.index) {
+										route.index({ context, params });
+									}
 									break;
 							}
 						}

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -32,7 +32,7 @@ export const maxConcurrency = 2;
 export const tunnel = 'BrowserStackTunnel';
 
 // Support running unit tests from a web server that isn't the intern proxy
-export const initialBaseUrl: string = (function () {
+export const initialBaseUrl: string | null = (function () {
 	if (typeof location !== 'undefined' && location.pathname.indexOf('__intern/') > -1) {
 		return '/';
 	}

--- a/tests/unit/createRoute.ts
+++ b/tests/unit/createRoute.ts
@@ -69,7 +69,7 @@ suite('createRoute', () => {
 
 	test('guard() receives the context', () => {
 		const context: C = {};
-		let received: C;
+		let received: C = <any> undefined;
 		const route = createRoute({
 			guard ({ context }: R) {
 				received = context;
@@ -206,7 +206,7 @@ suite('createRoute', () => {
 	});
 
 	test('guard() receives the extracted parameters', () => {
-		let received: Parameters;
+		let received: Parameters = <any> undefined;
 		const route = <Route<DefaultParameters>> createRoute({
 			path: '/{foo}/{bar}?{baz}&{qux}',
 			guard ({ params }: R) {
@@ -281,7 +281,7 @@ suite('createRoute', () => {
 		const route = createRoute({
 			path: '/{foo}',
 			params () {
-				return null;
+				return <any> null;
 			}
 		});
 

--- a/tests/unit/createRouter.ts
+++ b/tests/unit/createRouter.ts
@@ -210,7 +210,7 @@ suite('createRouter', () => {
 			resumers.push(resume);
 		});
 
-		let dispatched = false;
+		let dispatched: boolean | undefined = false;
 		router.dispatch({} as C, '/foo').then(d => {
 			dispatched = d;
 		});
@@ -219,11 +219,11 @@ suite('createRouter', () => {
 
 		return Promise.resolve().then(() => {
 			assert.isFalse(dispatched);
-			resumers.shift()();
+			(<any> resumers.shift())();
 			return delay(10);
 		}).then(() => {
 			assert.isFalse(dispatched);
-			resumers.shift()();
+			(<any> resumers.shift())();
 			return delay(10);
 		}).then(() => {
 			assert.isTrue(dispatched);
@@ -239,7 +239,7 @@ suite('createRouter', () => {
 			exec () { executed = true; }
 		}));
 
-		let resume: () => void;
+		let resume: () => void = <any> undefined;
 		router.on('navstart', event => {
 			resume = event.defer().resume;
 		});

--- a/tests/unit/history/createHashHistory.ts
+++ b/tests/unit/history/createHashHistory.ts
@@ -11,7 +11,7 @@ suite('createHashHistory', () => {
 	// Mask the globals so tests are forced to explicitly reference the
 	// correct window.
 	/* tslint:disable */
-	const location: void = null;
+	const location: void = <any> null;
 	/* tslint:enable */
 
 	let sandbox: HTMLIFrameElement;
@@ -26,7 +26,7 @@ suite('createHashHistory', () => {
 
 	afterEach(() => {
 		document.body.removeChild(sandbox);
-		sandbox = null;
+		sandbox = <any> null;
 	});
 
 	test('initializes current path to current location', () => {

--- a/tests/unit/history/createStateHistory.ts
+++ b/tests/unit/history/createStateHistory.ts
@@ -11,8 +11,8 @@ suite('createStateHistory', () => {
 	// Mask the globals so tests are forced to explicitly reference the
 	// correct window.
 	/* tslint:disable */
-	const history: void = null;
-	const location: void = null;
+	const history: void = <any> null;
+	const location: void = <any> null;
 	/* tslint:enable */
 
 	let sandbox: HTMLIFrameElement;
@@ -27,7 +27,7 @@ suite('createStateHistory', () => {
 
 	afterEach(() => {
 		document.body.removeChild(sandbox);
-		sandbox = null;
+		sandbox = <any> null;
 	});
 
 	test('initializes current path to current location', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
 		"removeComments": false,
 		"sourceMap": true,
 		"target": "es5",
-		"moduleResolution": "classic"
+		"moduleResolution": "classic",
+		"strictNullChecks": true
 	},
 	"include": [
 		"./src/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,45 +1,33 @@
 {
-	"version": "1.8.10",
+	"version": "2.0.0",
 	"compilerOptions": {
 		"declaration": false,
 		"module": "umd",
 		"noImplicitAny": true,
 		"outDir": "_build/",
+		"baseUrl": "node_modules",
+		"paths": {
+			"dojo-has/*": [
+				"dojo-has/dist/umd/*"
+			],
+			"dojo-shim/*": [
+				"dojo-shim/dist/umd/*"
+			],
+			"dojo-core/*": [
+				"dojo-core/dist/umd/*"
+			],
+			"dojo-compose/*": [
+				"dojo-compose/dist/umd/*"
+			]
+		},
 		"removeComments": false,
 		"sourceMap": true,
 		"target": "es5",
 		"moduleResolution": "classic"
 	},
-	"filesGlob": [
+	"include": [
 		"./src/**/*.ts",
 		"./tests/**/*.ts",
-		"./typings/index.d.ts"
-	],
-	"files": [
-		"./src/_path.ts",
-		"./src/createRoute.ts",
-		"./src/createRouter.ts",
-		"./src/history/_alias-ambient-history.d.ts",
-		"./src/history/createHashHistory.ts",
-		"./src/history/createMemoryHistory.ts",
-		"./src/history/createStateHistory.ts",
-		"./src/history/interfaces.d.ts",
-		"./src/interfaces.d.ts",
-		"./src/main.ts",
-		"./tests/functional/all.ts",
-		"./tests/intern-local.ts",
-		"./tests/intern-saucelabs.ts",
-		"./tests/intern.ts",
-		"./tests/support/Reporter.ts",
-		"./tests/support/util.ts",
-		"./tests/unit/all.ts",
-		"./tests/unit/createRoute.ts",
-		"./tests/unit/createRouter.ts",
-		"./tests/unit/history/all.ts",
-		"./tests/unit/history/createHashHistory.ts",
-		"./tests/unit/history/createMemoryHistory.ts",
-		"./tests/unit/history/createStateHistory.ts",
-		"./tests/unit/main.ts",
 		"./typings/index.d.ts"
 	]
 }

--- a/typings.json
+++ b/typings.json
@@ -1,11 +1,5 @@
 {
 	"name": "dojo-routing",
-	"globalDependencies": {
-		"dojo-compose": "npm:dojo-compose",
-		"dojo-core": "npm:dojo-core",
-		"dojo-has": "npm:dojo-has",
-		"dojo-shim": "npm:dojo-shim"
-	},
 	"devDependencies": {
 		"chai": "registry:npm/chai#3.5.0+20160415060238",
 		"glob": "registry:npm/glob#6.0.0+20160211003958",


### PR DESCRIPTION
Dependant on has, shim, core & compose TS2.0 updates
- [x] Upgrade to TS2.0 (beta)
- [x] Convert to use `paths` and `baseUrl` for UMD type discovery
- [x] Add `strictNullChecks`
- [ ] Add `noImplicitThis`

Fixes #21 
