### PR TITLE
Ignore hashchange events for the current path

### DIFF
--- a/src/history/createHashHistory.ts
+++ b/src/history/createHashHistory.ts
@@ -79,11 +79,16 @@ const createHashHistory: HashHistoryFactory = compose.mixin(createEvented, {
 
 		instance.own(on(window, 'hashchange', () => {
 			const path = browserLocation.hash.slice(1);
-			privateState.current = path;
-			instance.emit({
-				type: 'change',
-				value: path
-			});
+
+			// Ignore hashchange for the current path. Guards against browsers firing hashchange when the history
+			// manager sets the hash.
+			if (path !== privateState.current) {
+				privateState.current = path;
+				instance.emit({
+					type: 'change',
+					value: path
+				});
+			}
 		}));
 	}
 });

--- a/tests/unit/history/createHashHistory.ts
+++ b/tests/unit/history/createHashHistory.ts
@@ -47,12 +47,17 @@ suite('createHashHistory', () => {
 
 	test('emits change when path is updated', () => {
 		const history = createHashHistory({ window: sandbox.contentWindow });
-		let emittedValue = '';
+		let emittedValues: string[] = [];
 		history.on('change', ({ value }) => {
-			emittedValue = value;
+			emittedValues.push(value);
 		});
 		history.set('/foo');
-		assert.equal(emittedValue, '/foo');
+
+		return new Promise((resolve) => setTimeout(resolve, 500))
+			.then(() => {
+				assert.lengthOf(emittedValues, 1);
+				assert.equal(emittedValues[0], '/foo');
+			});
 	});
 
 	test('replace path', () => {
@@ -64,12 +69,17 @@ suite('createHashHistory', () => {
 
 	test('emits change when path is replaced', () => {
 		const history = createHashHistory({ window: sandbox.contentWindow });
-		let emittedValue = '';
+		let emittedValues: string[] = [];
 		history.on('change', ({ value }) => {
-			emittedValue = value;
+			emittedValues.push(value);
 		});
 		history.replace('/foo');
-		assert.equal(emittedValue, '/foo');
+
+		return new Promise((resolve) => setTimeout(resolve, 500))
+			.then(() => {
+				assert.lengthOf(emittedValues, 1);
+				assert.equal(emittedValues[0], '/foo');
+			});
 	});
 
 	test('does not add a new history entry when path is replaced', () => {


### PR DESCRIPTION
Setting the hash triggers a hashchange. Instead ignore hashchange events
for the current path. Fixes #20.
