### PR TITLE
Replace Router#observeHistory()

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ By default `start()` dispatches for the current history value. You can disable t
 router.start({ dispatchCurrent: false });
 ```
 
-The context for these dispatches defaults to a frozen, empty object. You can configure it when creating the router:
+The context for these dispatches defaults to an empty object. A new object is used for every dispatch. You can configure the context when creating the router:
 
 ```ts
 const router = createRouter({

--- a/README.md
+++ b/README.md
@@ -503,12 +503,39 @@ const history = createMemoryHistory();
 
 The `createMemoryHistory()` factory accepts a `path` option. It defaults to the empty string.
 
-#### Wiring History manager changes to Router dispatches
+#### Automatically observing a history manager
 
-Although you can manually wire a History manager `change` event to a `Router#dispatch()`, a utility function `Router#observeHistory()` will take care of the wiring for you. It takes a History manager, a Context and whether it should fire an initial dispatch.  An example of using it with a `StateHistory` manager:
+You could manually wire a history manager's `change` event to a `Router#dispatch()`, but that's a bit cumbersome. Instead you can provide the history manager when creating the router, and then use the `start()` method to make the router observe the history manager:
 
 ```ts
-router.observeHistory(createStateHistory(), { 'some': 'context' }, true);
+const router = createRouter({ history: createStateHistory() });
+router.start();
+```
+
+By default `start()` dispatches for the current history value. You can disable this:
+
+```ts
+router.start({ dispatchCurrent: false });
+```
+
+The context for these dispatches defaults to a frozen, empty object. You can configure it when creating the router:
+
+```ts
+const router = createRouter({
+	context: { someKey: 'someValue' },
+	history: createStateHistory()
+});
+```
+
+Provide a function if you want a new context for every dispatch:
+
+```ts
+const router = createRouter({
+	context() {
+		return { someKey: 'someValue' };
+	},
+	history: createStateHistory()
+});
 ```
 
 ## How do I use this package?

--- a/src/createRouter.ts
+++ b/src/createRouter.ts
@@ -63,14 +63,6 @@ export interface RouterMixin {
 	append(add: Route<Parameters> | Route<Parameters>[]): void;
 
 	/**
-	 * Observe History, auto-wires the History change event to dispatch
-	 * @param history A History manager.
-	 * @param context A context object that is provided when executing selected routes.
-	 * @param dispatchInitial Whether to immediately dispatch with the History's current value.
-	 */
-	observeHistory(history: History, context: Context, dispatchInitial?: boolean): PausableHandle;
-
-	/**
 	 * Select and execute routes for a given path.
 	 * @param context A context object that is provided when executing selected routes.
 	 * @param path The path.
@@ -78,6 +70,16 @@ export interface RouterMixin {
 	 *   on whether dispatching succeeded.
 	 */
 	dispatch(context: Context, path: string): Task<boolean>;
+
+	/**
+	 * Start the router.
+	 *
+	 * Observes the history manager provided when the router was created for change events and dispatches routes in
+	 * response. Noop if no history manager was provided.
+	 *
+	 * @param options An optional options object, can be used to prevent the router from immediately dispatching.
+	 */
+	start(options?: StartOptions): PausableHandle;
 }
 
 export interface RouterOverrides {
@@ -96,11 +98,32 @@ export type Router = Evented & RouterMixin & RouterOverrides;
  */
 export interface RouterOptions extends EventedOptions {
 	/**
+	 * A Context object to be used for all requests, or a function that provides such an object, called for each
+	 * dispatch.
+	 */
+	context?: Context | (() => Context);
+
+	/**
 	 * A handler called when no routes match the dispatch path.
 	 * @param request An object whose `context` property contains the dispatch context. No extracted parameters
 	 *   are available.
 	 */
-	fallback?(request: Request<any>): void;
+	fallback?: (request: Request<any>) => void;
+
+	/**
+	 * The history manager. Routes will be dispatched in response to change events emitted by the manager.
+	 */
+	history?: History;
+}
+
+/**
+ * The options for the router's start() method.
+ */
+export interface StartOptions {
+	/**
+	 * Whether to immediately dispatch with the history's current value.
+	 */
+	dispatchCurrent: boolean;
 }
 
 export interface RouterFactory extends ComposeFactory<Router, RouterOptions> {
@@ -112,13 +135,11 @@ export interface RouterFactory extends ComposeFactory<Router, RouterOptions> {
 }
 
 interface PrivateState {
-	fallback?(request: Request<any>): void;
-	observedHistory: null | {
-		history: History;
-		context: Context;
-		listener: PausableHandle;
-	};
+	contextFactory: () => Context;
+	fallback?: (request: Request<any>) => void;
+	history?: History;
 	routes: Route<Parameters>[];
+	started?: boolean;
 }
 
 const privateStateMap = new WeakMap<Router, PrivateState>();
@@ -150,28 +171,6 @@ const createRouter: RouterFactory = compose.mixin(createEvented, {
 			else {
 				routes.push(add);
 			}
-		},
-
-		observeHistory(
-			this: Router,
-			history: History,
-			context: Context,
-			dispatchInitial: boolean = false
-		): PausableHandle {
-			const state = privateStateMap.get(this);
-			if (state.observedHistory) {
-				throw new Error('observeHistory can only be called once');
-			}
-			const listener = pausable(history, 'change', (event: HistoryChangeEvent) => {
-				this.dispatch(context, event.value);
-			});
-			state.observedHistory = { history, listener, context };
-			if (dispatchInitial) {
-				this.dispatch(context, history.current);
-			}
-			this.own(listener);
-			this.own(history);
-			return listener;
 		},
 
 		dispatch(this: Router, context: Context, path: string): Task<boolean> {
@@ -237,12 +236,53 @@ const createRouter: RouterFactory = compose.mixin(createEvented, {
 					() => false
 				).then(resolve, reject);
 			}, cancel);
+		},
+
+		start(this: Router, { dispatchCurrent }: StartOptions = { dispatchCurrent: true }): PausableHandle {
+			const state = privateStateMap.get(this);
+			if (state.started) {
+				throw new Error('start can only be called once');
+			}
+			state.started = true;
+
+			const { contextFactory, history } = state;
+			if (!history) {
+				return {
+					pause() {},
+					resume() {},
+					destroy() {}
+				};
+			}
+
+			const listener = pausable(history, 'change', (event: HistoryChangeEvent) => {
+				this.dispatch(contextFactory(), event.value);
+			});
+			this.own(listener);
+
+			if (dispatchCurrent) {
+				this.dispatch(contextFactory(), history.current);
+			}
+
+			return listener;
 		}
 	},
-	initialize(instance: Router, { fallback }: RouterOptions = {}) {
+	initialize(instance: Router, { context = Object.freeze({}), fallback, history }: RouterOptions = {}) {
+		let contextFactory: () => Context;
+		if (typeof context === 'function') {
+			contextFactory = context;
+		}
+		else {
+			contextFactory = () => context;
+		}
+
+		if (history) {
+			instance.own(history);
+		}
+
 		privateStateMap.set(instance, {
+			contextFactory,
 			fallback,
-			observedHistory: null,
+			history,
 			routes: []
 		});
 	}

--- a/src/createRouter.ts
+++ b/src/createRouter.ts
@@ -266,13 +266,21 @@ const createRouter: RouterFactory = compose.mixin(createEvented, {
 			return listener;
 		}
 	},
-	initialize(instance: Router, { context = Object.freeze({}), fallback, history }: RouterOptions = {}) {
+	initialize(instance: Router, { context, fallback, history }: RouterOptions = {}) {
 		let contextFactory: () => Context;
 		if (typeof context === 'function') {
 			contextFactory = context;
 		}
+		else if (typeof context === 'undefined') {
+			contextFactory = () => {
+				return {};
+			};
+		}
 		else {
-			contextFactory = () => context;
+			// Assign to a constant since the context variable may be changed after the function is defined,
+			// which would violate its typing.
+			const sharedContext = context;
+			contextFactory = () => sharedContext;
 		}
 
 		if (history) {

--- a/tests/unit/createRouter.ts
+++ b/tests/unit/createRouter.ts
@@ -428,67 +428,123 @@ suite('createRouter', () => {
 		});
 	});
 
-	test('#observeHistory wires dispatch to a history change event', () => {
-		const router = createRouter();
-		const dispatch = stub(router, 'dispatch');
-
-		const history = createMemoryHistory();
-		const context = { 'foo': 'bar' };
-
-		router.observeHistory(history, context, false);
-		history.set('/foo');
-		assert.isTrue(dispatch.calledWith(context, '/foo'));
+	test('#start is a noop if the router was created without a history manager', () => {
+		assert.doesNotThrow(() => {
+			const listener = createRouter().start();
+			listener.pause();
+			listener.resume();
+			listener.destroy();
+		});
 	});
 
-	test('#observeHistory returns a pausable handler', () => {
-		const router = createRouter();
+	test('#start wires dispatch to a history change event', () => {
+		const history = createMemoryHistory();
+		const router = createRouter({ history });
 		const dispatch = stub(router, 'dispatch');
 
-		const history = createMemoryHistory();
-		const context = { 'foo': 'bar' };
+		router.start({ dispatchCurrent: false });
+		history.set('/foo');
+		assert.isTrue(dispatch.calledWith({}, '/foo'));
+	});
 
-		const listener = router.observeHistory(history, context, false);
+	test('#start returns a pausable handler', () => {
+		const history = createMemoryHistory();
+		const router = createRouter({ history });
+		const dispatch = stub(router, 'dispatch');
+
+		const listener = router.start({ dispatchCurrent: false });
 		listener.pause();
 		history.set('/foo');
 		assert.isFalse(dispatch.called);
 
 		listener.resume();
 		history.set('/bar');
-		assert.isTrue(dispatch.calledWith(context, '/bar'));
+		assert.isTrue(dispatch.calledWith({}, '/bar'));
 	});
 
-	test('#observeHistory can dispatch immediately', () => {
-		const router = createRouter();
+	test('#start can immediately dispatch for the current history value', () => {
+		const history = createMemoryHistory({ path: '/foo' });
+		const router = createRouter({ history });
 		const dispatch = stub(router, 'dispatch');
 
-		const history = createMemoryHistory({ path: '/foo' });
-		const context = { 'foo': 'bar' };
-
-		router.observeHistory(history, context, true);
-		assert.isTrue(dispatch.calledWith(context, '/foo'));
+		router.start({ dispatchCurrent: true });
+		assert.isTrue(dispatch.calledWith({}, '/foo'));
 	});
 
-	test('#observeHistory does not dispatch immediately by default', () => {
-		const router = createRouter();
+	test('#start can be configured not to immediately dispatch for the current history value', () => {
+		const history = createMemoryHistory({ path: '/foo' });
+		const router = createRouter({ history });
 		const dispatch = stub(router, 'dispatch');
 
-		const history = createMemoryHistory({ path: '/foo' });
-		const context = { 'foo': 'bar' };
-
-		router.observeHistory(history, context);
+		router.start({ dispatchCurrent: false });
 		assert.isTrue(dispatch.notCalled);
 	});
 
-	test('#observeHistory throws if already called', () => {
-		const router = createRouter();
-		const history = createMemoryHistory();
+	test('#start dispatches immediately by default', () => {
+		const history = createMemoryHistory({ path: '/foo' });
+		const router = createRouter({ history });
+		const dispatch = stub(router, 'dispatch');
 
-		function observeHistory() {
-			router.observeHistory(history, {}, false);
+		router.start();
+		assert.isTrue(dispatch.calledOnce);
+	});
+
+	test('#start throws if already called', () => {
+		const history = createMemoryHistory();
+		const router = createRouter({ history });
+
+		function start() {
+			router.start();
 		};
 
-		observeHistory();
+		start();
 
-		assert.throws(observeHistory, /observeHistory can only be called once/);
+		assert.throws(start, /start can only be called once/);
+	});
+
+	test('without a provided context, #start dispatches with a frozen empty object as the context', () => {
+		const history = createMemoryHistory({ path: '/foo' });
+		const router = createRouter({ history });
+		const dispatch = stub(router, 'dispatch');
+
+		router.start();
+		const { args: [ initialContext ] } = dispatch.firstCall;
+		assert.isTrue(Object.isFrozen(initialContext));
+		assert.deepEqual(initialContext, {});
+
+		history.set('/bar');
+		const { args: [ nextContext ] } = dispatch.secondCall;
+		assert.strictEqual(nextContext, initialContext);
+	});
+
+	test('with a provided context, #start dispatches with that object as the context', () => {
+		const context = {};
+		const history = createMemoryHistory({ path: '/foo' });
+		const router = createRouter({ context, history });
+		const dispatch = stub(router, 'dispatch');
+
+		router.start();
+		const { args: [ initialContext ] } = dispatch.firstCall;
+		assert.strictEqual(initialContext, context);
+
+		history.set('/bar');
+		const { args: [ nextContext ] } = dispatch.secondCall;
+		assert.strictEqual(nextContext, context);
+	});
+
+	test('with a provided context factory, #start dispatches with factory\'s value as the context', () => {
+		const contexts = [ { first: true }, { second: true } ];
+		const context = () => contexts.shift();
+		const history = createMemoryHistory({ path: '/foo' });
+		const router = createRouter({ context, history });
+		const dispatch = stub(router, 'dispatch');
+
+		router.start();
+		const { args: [ initialContext ] } = dispatch.firstCall;
+		assert.deepEqual(initialContext, { first: true });
+
+		history.set('/bar');
+		const { args: [ nextContext ] } = dispatch.secondCall;
+		assert.deepEqual(nextContext, { second: true });
 	});
 });

--- a/tests/unit/createRouter.ts
+++ b/tests/unit/createRouter.ts
@@ -502,19 +502,19 @@ suite('createRouter', () => {
 		assert.throws(start, /start can only be called once/);
 	});
 
-	test('without a provided context, #start dispatches with a frozen empty object as the context', () => {
+	test('without a provided context, #start dispatches with an empty object as the context', () => {
 		const history = createMemoryHistory({ path: '/foo' });
 		const router = createRouter({ history });
 		const dispatch = stub(router, 'dispatch');
 
 		router.start();
 		const { args: [ initialContext ] } = dispatch.firstCall;
-		assert.isTrue(Object.isFrozen(initialContext));
 		assert.deepEqual(initialContext, {});
 
 		history.set('/bar');
 		const { args: [ nextContext ] } = dispatch.secondCall;
-		assert.strictEqual(nextContext, initialContext);
+		assert.notStrictEqual(nextContext, initialContext);
+		assert.deepEqual(nextContext, {});
 	});
 
 	test('with a provided context, #start dispatches with that object as the context', () => {


### PR DESCRIPTION
The history manager can now be provided when creating the router. It is
still optional, to allow for routers to be created that handle
server-side requests in Node.js.

Similarly a context object can be provided, or a factory function which
returns a context object for each request.

The new Router#start() causes the router to observe the history manager
and dispatch requests in response. By default it performs an immediate
dispatch based on the current history value. Calling start() on a router
that does not have a history manager is a noop. start() can only be
called once.

Fixes #18.
