### PR TITLE
Allow routes to request redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ router.dispatch(context, '/about');
 
 Route selection starts in a future turn. An async Task is returned (see [`dojo-core`](https://github.com/dojo/core)) which is resolved with a result object. The object has a `success` property which is `false` if no route was selected, or dispatch was canceled. It's `true` otherwise.
 
+An optional `redirect` property may be present, in case one of the matched routes requested a redirect. The value of the `redirect` property is the new path. It may be an empty string. No routes are executed when a redirect is returned, instead you're expected to change the path and call `dispatch()` again.
+
 You can cancel the task in case a new navigation event occurs.
 
 ### Creating routes
@@ -521,6 +523,8 @@ router.start({ dispatchCurrent: false });
 ```
 
 As an added benefit, when you use `start()` it ensures the previous dispatch is canceled when the history changes and it dispatches a new request.
+
+`start()` also ensures history is replaced with the new path when routes request a redirect.
 
 The context for these dispatches defaults to an empty object. A new object is used for every dispatch. You can configure the context when creating the router:
 

--- a/README.md
+++ b/README.md
@@ -520,6 +520,8 @@ By default `start()` dispatches for the current history value. You can disable t
 router.start({ dispatchCurrent: false });
 ```
 
+As an added benefit, when you use `start()` it ensures the previous dispatch is canceled when the history changes and it dispatches a new request.
+
 The context for these dispatches defaults to an empty object. A new object is used for every dispatch. You can configure the context when creating the router:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ const context: AppContext = {
 router.dispatch(context, '/about');
 ```
 
-Route selection starts in a future turn. An async Task is returned (see [`dojo-core`](https://github.com/dojo/core)) which is resolved with `true` if a route was executed, or `false` if no route was selected. You can cancel the task in case a new navigation event occurs.
+Route selection starts in a future turn. An async Task is returned (see [`dojo-core`](https://github.com/dojo/core)) which is resolved with a result object. The object has a `success` property which is `false` if no route was selected, or dispatch was canceled. It's `true` otherwise.
+
+You can cancel the task in case a new navigation event occurs.
 
 ### Creating routes
 

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "dojo-compose": ">=2.0.0-beta.10",
-    "dojo-core": ">=2.0.0-alpha.12",
+    "dojo-compose": ">=2.0.0-beta.12",
+    "dojo-core": ">=2.0.0-alpha.15",
     "dojo-has": ">=2.0.0-alpha.4",
-    "dojo-shim": ">=2.0.0-alpha.4"
+    "dojo-shim": ">=2.0.0-beta.1"
   },
   "devDependencies": {
     "codecov.io": "0.1.6",

--- a/src/createRouter.ts
+++ b/src/createRouter.ts
@@ -264,13 +264,17 @@ const createRouter: RouterFactory = compose.mixin(createEvented, {
 				};
 			}
 
+			let lastDispatch: Task<DispatchResult>;
 			const listener = pausable(history, 'change', (event: HistoryChangeEvent) => {
-				this.dispatch(contextFactory(), event.value);
+				if (lastDispatch) {
+					lastDispatch.cancel();
+				}
+				lastDispatch = this.dispatch(contextFactory(), event.value);
 			});
 			this.own(listener);
 
 			if (dispatchCurrent) {
-				this.dispatch(contextFactory(), history.current);
+				lastDispatch = this.dispatch(contextFactory(), history.current);
 			}
 
 			return listener;

--- a/tests/unit/createRoute.ts
+++ b/tests/unit/createRoute.ts
@@ -61,7 +61,13 @@ suite('createRoute', () => {
 		const route = <Route<DefaultParameters>> createRoute({
 			path: '/{foo}/{bar}?{baz}&{qux}'
 		});
-		const [{ params }] = route.select({} as C, ['quux', 'corge'], false, new UrlSearchParams('baz=grault&qux=garply'));
+
+		const result = route.select({} as C, ['quux', 'corge'], false, new UrlSearchParams('baz=grault&qux=garply'));
+		if (typeof result === 'string') {
+			throw new TypeError('Unexpected result');
+		}
+
+		const [ { params } ] = result;
 		assert.deepEqual(params, {
 			foo: 'quux',
 			bar: 'corge',
@@ -74,7 +80,13 @@ suite('createRoute', () => {
 		const route = <Route<DefaultParameters>> createRoute({
 			path: '/{foo}/{bar}?{baz}&{qux}'
 		});
-		const [{ params }] = route.select({} as C, ['quux', 'corge'], false, new UrlSearchParams('baz=grault'));
+
+		const result = route.select({} as C, ['quux', 'corge'], false, new UrlSearchParams('baz=grault'));
+		if (typeof result === 'string') {
+			throw new TypeError('Unexpected result');
+		}
+
+		const [ { params } ] = result;
 		assert.deepEqual(params, {
 			foo: 'quux',
 			bar: 'corge',
@@ -86,7 +98,13 @@ suite('createRoute', () => {
 		const route = <Route<DefaultParameters>> createRoute({
 			path: '/{foo}/{bar}?{baz}&{qux}'
 		});
-		const [{ params }] = route.select({} as C, ['quux', 'corge'], false, new UrlSearchParams('baz=grault&baz=garply'));
+
+		const result = route.select({} as C, ['quux', 'corge'], false, new UrlSearchParams('baz=grault&baz=garply'));
+		if (typeof result === 'string') {
+			throw new TypeError('Unexpected result');
+		}
+
+		const [ { params } ] = result;
 		assert.deepEqual(params, {
 			foo: 'quux',
 			bar: 'corge',
@@ -196,7 +214,13 @@ suite('createRoute', () => {
 				};
 			}
 		});
-		const [{ params }] = route.select({} as C, ['baz', 'qux'], false, new UrlSearchParams());
+
+		const result = route.select({} as C, ['baz', 'qux'], false, new UrlSearchParams());
+		if (typeof result === 'string') {
+			throw new TypeError('Unexpected result');
+		}
+
+		const [ { params } ] = result;
 		assert.deepEqual(params, {
 			upper: 'BAZ',
 			barIsQux: true
@@ -217,7 +241,13 @@ suite('createRoute', () => {
 				};
 			}
 		});
-		const [{ params }] = route.select({} as C, [], false, new UrlSearchParams('foo=baz&bar=qux&foo=BAZ'));
+
+		const result = route.select({} as C, [], false, new UrlSearchParams('foo=baz&bar=qux&foo=BAZ'));
+		if (typeof result === 'string') {
+			throw new TypeError('Unexpected result');
+		}
+
+		const [ { params } ] = result;
 		assert.deepEqual(params, {
 			fooArr: ['baz', 'BAZ'],
 			barIsQux: true
@@ -250,6 +280,10 @@ suite('createRoute', () => {
 	test('without a path, is selected for zero segments', () => {
 		const route = createRoute();
 		const selections = route.select({} as C, [], false, new UrlSearchParams());
+		if (typeof selections === 'string') {
+			throw new TypeError('Unexpected result');
+		}
+
 		assert.lengthOf(selections, 1);
 		assert.strictEqual(selections[0].route, route);
 	});
@@ -263,6 +297,10 @@ suite('createRoute', () => {
 	test('with a path, is selected if segments match', () => {
 		const route = createRoute({ path: '/foo/bar' });
 		const selections = route.select({} as C, ['foo', 'bar'], false, new UrlSearchParams());
+		if (typeof selections === 'string') {
+			throw new TypeError('Unexpected result');
+		}
+
 		assert.lengthOf(selections, 1);
 		assert.strictEqual(selections[0].route, route);
 	});
@@ -289,6 +327,10 @@ suite('createRoute', () => {
 		deep.append(deeper);
 
 		const selections = root.select({} as C, ['foo', 'bar', 'baz'], false, new UrlSearchParams());
+		if (typeof selections === 'string') {
+			throw new TypeError('Unexpected result');
+		}
+
 		assert.lengthOf(selections, 3);
 		const [{ route: first }, { route: second }, { route: third }] = selections;
 		assert.strictEqual(first, root);
@@ -386,6 +428,32 @@ suite('createRoute', () => {
 		assert.lengthOf(selections, 0);
 	});
 
+	test('guards can request redirects by returning path strings', () => {
+		const root = createRoute({ path: '/root' });
+		const deep = createRoute({
+			path: '/deep',
+			guard() {
+				return '/shallow';
+			}
+		});
+		root.append(deep);
+
+		assert.strictEqual(root.select({} as C, ['root', 'deep'], false, new UrlSearchParams()), '/shallow');
+	});
+
+	test('guards can request redirects by returning empty path strings', () => {
+		const root = createRoute({ path: '/root' });
+		const deep = createRoute({
+			path: '/deep',
+			guard() {
+				return '';
+			}
+		});
+		root.append(deep);
+
+		assert.strictEqual(root.select({} as C, ['root', 'deep'], false, new UrlSearchParams()), '');
+	});
+
 	test('extracts path parameters for each nested route', () => {
 		const root = createRoute({ path: '/foo/{param}' });
 		const deep = createRoute({ path: '/bar/{param}' });
@@ -394,6 +462,10 @@ suite('createRoute', () => {
 		deep.append(deeper);
 
 		const selections = root.select({} as C, ['foo', 'root', 'bar', 'deep', 'baz', 'deeper'], false, new UrlSearchParams());
+		if (typeof selections === 'string') {
+			throw new TypeError('Unexpected result');
+		}
+
 		assert.lengthOf(selections, 3);
 		const [{ params: first }, { params: second }, { params: third }] = selections;
 		assert.deepEqual(first, { param: 'root' });

--- a/tests/unit/createRouter.ts
+++ b/tests/unit/createRouter.ts
@@ -11,17 +11,17 @@ import { DefaultParameters, Context as C, Request, Parameters } from '../../src/
 interface R extends Request<Parameters> {};
 
 suite('createRouter', () => {
-	test('dispatch resolves to false if no route was executed', () => {
-		return createRouter().dispatch({} as C, '/').then(d => {
-			assert.isFalse(d);
+	test('dispatch resolves to unsuccessful result if no route was executed', () => {
+		return createRouter().dispatch({} as C, '/').then(result => {
+			assert.deepEqual(result, { success: false });
 		});
 	});
 
-	test('dispatch resolves to true if a route was executed', () => {
+	test('dispatch resolves to successful result if a route was executed', () => {
 		const router = createRouter();
 		router.append(createRoute());
-		return router.dispatch({} as C, '/').then(d => {
-			assert.isTrue(d);
+		return router.dispatch({} as C, '/').then(result => {
+			assert.deepEqual(result, { success: true });
 		});
 	});
 
@@ -166,7 +166,7 @@ suite('createRouter', () => {
 			event.cancel();
 		});
 
-		return router.dispatch({} as C, '/foo').then(d => {
+		return router.dispatch({} as C, '/foo').then(({ success: d }) => {
 			assert.isFalse(d);
 		});
 	});
@@ -179,7 +179,7 @@ suite('createRouter', () => {
 			Promise.resolve().then(cancel);
 		});
 
-		return router.dispatch({} as C, '/foo').then(d => {
+		return router.dispatch({} as C, '/foo').then(({ success: d }) => {
 			assert.isFalse(d);
 		});
 	});
@@ -192,7 +192,7 @@ suite('createRouter', () => {
 			Promise.resolve().then(resume);
 		});
 
-		return router.dispatch({} as C, '/foo').then(d => {
+		return router.dispatch({} as C, '/foo').then(({ success: d }) => {
 			assert.isTrue(d);
 		});
 	});
@@ -212,7 +212,7 @@ suite('createRouter', () => {
 		});
 
 		let dispatched: boolean | undefined = false;
-		router.dispatch({} as C, '/foo').then(d => {
+		router.dispatch({} as C, '/foo').then(({ success: d }) => {
 			dispatched = d;
 		});
 
@@ -264,7 +264,7 @@ suite('createRouter', () => {
 		});
 
 		const context = {} as C;
-		return router.dispatch(context, '/foo').then(d => {
+		return router.dispatch(context, '/foo').then(({ success: d }) => {
 			assert.isTrue(d);
 			assert.ok(received);
 			assert.strictEqual(received.context, context);
@@ -306,7 +306,7 @@ suite('createRouter', () => {
 		deep.append(deeper);
 		router.append(root);
 
-		return router.dispatch({} as C, 'foo/bar/baz').then(d => {
+		return router.dispatch({} as C, 'foo/bar/baz').then(({ success: d }) => {
 			assert.isTrue(d);
 		});
 	});
@@ -321,7 +321,7 @@ suite('createRouter', () => {
 			deep.append(deeper);
 			router.append(root);
 
-			return router.dispatch({} as C, `foo/bar/baz${withSlash ? '/' : ''}`).then(d => {
+			return router.dispatch({} as C, `foo/bar/baz${withSlash ? '/' : ''}`).then(({ success: d }) => {
 				assert.isTrue(d === withSlash, `there is ${withSlash ? 'a' : 'no'} trailing slash`);
 			});
 		}));
@@ -337,7 +337,7 @@ suite('createRouter', () => {
 			deep.append(deeper);
 			router.append(root);
 
-			return router.dispatch({} as C, `foo/bar/baz${withSlash ? '/' : ''}`).then(d => {
+			return router.dispatch({} as C, `foo/bar/baz${withSlash ? '/' : ''}`).then(({ success: d }) => {
 				assert.isTrue(d !== withSlash, `there is ${withSlash ? 'a' : 'no'} trailing slash`);
 			});
 		}));
@@ -356,7 +356,7 @@ suite('createRouter', () => {
 			deep.append(deeper);
 			router.append(root);
 
-			return router.dispatch({} as C, `foo/bar/baz${withSlash ? '/' : ''}`).then(d => {
+			return router.dispatch({} as C, `foo/bar/baz${withSlash ? '/' : ''}`).then(({ success: d }) => {
 				assert.isTrue(d, `there is ${withSlash ? 'a' : 'no'} trailing slash`);
 			});
 		}));
@@ -366,7 +366,7 @@ suite('createRouter', () => {
 		const router = createRouter();
 		router.append(createRoute({ path: '/foo' }));
 
-		return router.dispatch({} as C, '/foo?bar').then(d => {
+		return router.dispatch({} as C, '/foo?bar').then(({ success: d }) => {
 			assert.isTrue(d);
 		});
 	});
@@ -375,7 +375,7 @@ suite('createRouter', () => {
 		const router = createRouter();
 		router.append(createRoute({ path: '/foo' }));
 
-		return router.dispatch({} as C, '/foo#bar').then(d => {
+		return router.dispatch({} as C, '/foo#bar').then(({ success: d }) => {
 			assert.isTrue(d);
 		});
 	});
@@ -384,11 +384,11 @@ suite('createRouter', () => {
 		const router = createRouter();
 		router.append(createRoute({ path: '/foo' }));
 
-		return router.dispatch({} as C, '/foo?bar#baz').then(d => {
+		return router.dispatch({} as C, '/foo?bar#baz').then(({ success: d }) => {
 			assert.isTrue(d, '/foo?bar#baz');
 
 			return router.dispatch({} as C, '/foo#bar?baz');
-		}).then(d => {
+		}).then(({ success: d }) => {
 			assert.isTrue(d);
 		});
 	});
@@ -397,7 +397,7 @@ suite('createRouter', () => {
 		const router = createRouter();
 		router.append(createRoute({ path: '/foo/bar' }));
 
-		return router.dispatch({} as C, '//foo///bar').then(d => {
+		return router.dispatch({} as C, '//foo///bar').then(({ success: d }) => {
 			assert.isTrue(d);
 		});
 	});
@@ -413,17 +413,17 @@ suite('createRouter', () => {
 			}
 		}));
 
-		return router.dispatch({} as C, '/foo?bar=1&baz=2').then(d => {
+		return router.dispatch({} as C, '/foo?bar=1&baz=2').then(() => {
 			assert.deepEqual(extracted, {bar: '1', baz: '2'});
 
 			extracted = {};
 			return router.dispatch({} as C, '/foo?bar=3#baz=4');
-		}).then(d => {
+		}).then(() => {
 			assert.deepEqual(extracted, {bar: '3'});
 
 			extracted = {};
 			return router.dispatch({} as C, '/foo#bar=5?baz=6');
-		}).then(d => {
+		}).then(() => {
 			assert.deepEqual(extracted, {});
 		});
 	});


### PR DESCRIPTION
A route's guard() implementation may return a string which contains the
path it wants the user to be redirected to. This is propagated to the
dispatch result of the router.

When using Router#start() the history is automatically replaced with the
requested path, triggering another dispatch. Previous dispatches are canceled to avoid overlap.
