### PR TITLE
Allow dispatch errors to be captured

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ const route = createRoute({
 });
 ```
 
+You may return a thenable in order to [capture errors](#capturing-errors). Route dispatch does not wait for the thenable to resolve.
+
 ### Route hierarchies
 
 Routes can be appended to other routes:
@@ -162,6 +164,8 @@ const posts = createRoute({
 	}
 });
 ```
+
+You may return a thenable in order to [capture errors](#capturing-errors). Route dispatch does not wait for the thenable to resolve.
 
 ### Named parameters
 
@@ -373,6 +377,8 @@ posts.append(byId);
 
 No route will match `/posts/5/stats`, however there is a fallback for the `byId` route. The router will call `exec()` on the `posts` route and `fallback()` on the `byId` route.
 
+You may return a thenable in order to [capture errors](#capturing-errors). Route dispatch does not wait for the thenable to resolve.
+
 ### Preventing dispatches altogether
 
 You may want to prevent new routes from executing until the user has completed a certain task. You can listen to the `navstart` event emitted by the router to cancel or defer dispatches:
@@ -545,6 +551,10 @@ const router = createRouter({
 	history: createStateHistory()
 });
 ```
+
+### Capturing errors
+
+Errors that occur during dispatch are emitted under the `error` event. The event object contains the error as well as the context and path used for the dispatch.
 
 ## How do I use this package?
 

--- a/src/createRoute.ts
+++ b/src/createRoute.ts
@@ -2,6 +2,7 @@ import compose, { ComposeFactory } from 'dojo-compose/compose';
 import UrlSearchParams from 'dojo-core/UrlSearchParams';
 import { Hash } from 'dojo-core/interfaces';
 import WeakMap from 'dojo-shim/WeakMap';
+import { Thenable } from 'dojo-shim/interfaces';
 
 import { DefaultParameters, Context, Parameters, Request } from './interfaces';
 import {
@@ -37,7 +38,7 @@ export interface Selection {
 	/**
 	 * Which handler should be called when the route is executed.
 	 */
-	handler: (request: Request<Parameters>) => void;
+	handler: (request: Request<Parameters>) => void | Thenable<any>;
 
 	/**
 	 * The extracted parameters.
@@ -110,7 +111,7 @@ export interface RouteOptions<P> {
 	 * @param request An object whose `context` property contains the dispatch context. Extracted parameters are
 	 *   available under `params`.
 	 */
-	exec?(request: Request<P>): void;
+	exec?(request: Request<P>): void | Thenable<any>;
 
 	/**
 	 * If specified, causes the route to be selected if there are no nested routes that match the remainder of
@@ -118,7 +119,7 @@ export interface RouteOptions<P> {
 	 * @param request An object whose `context` property contains the dispatch context. Extracted parameters are
 	 *   available under `params`.
 	 */
-	fallback?(request: Request<P>): void;
+	fallback?(request: Request<P>): void | Thenable<any>;
 
 	/**
 	 * Callback used to determine whether the route should be selected after it's been matched.
@@ -135,7 +136,7 @@ export interface RouteOptions<P> {
 	 * @param request An object whose `context` property contains the dispatch context. Extracted parameters are
 	 *   available under `params`.
 	 */
-	index?(request: Request<P>): void;
+	index?(request: Request<P>): void | Thenable<any>;
 
 	/**
 	 * Callback used for constructing the `params` object from extracted parameters, and validating the parameters.
@@ -160,10 +161,10 @@ interface PrivateState {
 	trailingSlashMustMatch: boolean;
 
 	computeParams<P extends Parameters>(fromPathname: string[], searchParams: UrlSearchParams): null | P;
-	exec?(request: Request<Parameters>): void;
-	fallback?(request: Request<Parameters>): void;
+	exec?(request: Request<Parameters>): void | Thenable<any>;
+	fallback?(request: Request<Parameters>): void | Thenable<any>;
 	guard?(request: Request<Parameters>): string | boolean;
-	index?(request: Request<Parameters>): void;
+	index?(request: Request<Parameters>): void | Thenable<any>;
 }
 
 const privateStateMap = new WeakMap<Route<Parameters>, PrivateState>();


### PR DESCRIPTION
Errors that occur during dispatch are emitted under the `error` event.
The event object contains the error as well as the context and path used
for the dispatch.

Fixes #30.
