### PR TITLE
Use a generic for the Context

### DIFF
--- a/src/createRouter.ts
+++ b/src/createRouter.ts
@@ -56,11 +56,11 @@ export interface NavigationStartEvent extends TargettedEventObject {
 /**
  * Event object that is emitted for the 'error' event.
  */
-export interface ErrorEvent extends TargettedEventObject {
+export interface ErrorEvent<C extends Context> extends TargettedEventObject {
 	/**
 	 * The context that was being dispatched when the error occurred.
 	 */
-	context: Context;
+	context: C;
 
 	/**
 	 * The error.
@@ -75,7 +75,7 @@ export interface ErrorEvent extends TargettedEventObject {
 	/**
 	 * The router that emitted this event.
 	 */
-	target: Router;
+	target: Router<C>;
 }
 
 /**
@@ -96,19 +96,19 @@ export interface DispatchResult {
 /**
  * A router mixin.
  */
-export interface RouterMixin {
+export interface RouterMixin<C extends Context> {
 	/**
 	 * Append one or more routes.
 	 * @param routes A single route or an array containing 0 or more routes.
 	 */
-	append(add: Route<Parameters> | Route<Parameters>[]): void;
+	append(add: Route<Context, Parameters> | Route<Context, Parameters>[]): void;
 
 	/**
 	 * Select and execute routes for a given path.
 	 * @param context A context object that is provided when executing selected routes.
 	 * @param path The path.
 	 */
-	dispatch(context: Context, path: string): Task<DispatchResult>;
+	dispatch(context: C, path: string): Task<DispatchResult>;
 
 	/**
 	 * Start the router.
@@ -121,7 +121,7 @@ export interface RouterMixin {
 	start(options?: StartOptions): PausableHandle;
 }
 
-export interface RouterOverrides {
+export interface RouterOverrides<C extends Context> {
 	/**
 	 * Event emitted when dispatch is called, but before routes are selected.
 	 */
@@ -133,29 +133,29 @@ export interface RouterOverrides {
 	 * Certain errors may reject the task returned when dispatching, but this task is not always accessible and may
 	 * hide errors if it's canceled.
 	 */
-	on(type: 'error', listener: EventedListener<ErrorEvent>): Handle;
+	on(type: 'error', listener: EventedListener<ErrorEvent<C>>): Handle;
 
 	on(type: string, listener: EventedListener<TargettedEventObject>): Handle;
 }
 
-export type Router = Evented & RouterMixin & RouterOverrides;
+export type Router<C extends Context> = Evented & RouterMixin<C> & RouterOverrides<C>;
 
 /**
  * The options for the router.
  */
-export interface RouterOptions extends EventedOptions {
+export interface RouterOptions<C extends Context> extends EventedOptions {
 	/**
 	 * A Context object to be used for all requests, or a function that provides such an object, called for each
 	 * dispatch.
 	 */
-	context?: Context | (() => Context);
+	context?: C | (() => C);
 
 	/**
 	 * A handler called when no routes match the dispatch path.
 	 * @param request An object whose `context` property contains the dispatch context. No extracted parameters
 	 *   are available.
 	 */
-	fallback?: (request: Request<any>) => void | Thenable<any>;
+	fallback?: (request: Request<C, Parameters>) => void | Thenable<any>;
 
 	/**
 	 * The history manager. Routes will be dispatched in response to change events emitted by the manager.
@@ -173,23 +173,24 @@ export interface StartOptions {
 	dispatchCurrent: boolean;
 }
 
-export interface RouterFactory extends ComposeFactory<Router, RouterOptions> {
+export interface RouterFactory<C extends Context> extends ComposeFactory<Router<C>, RouterOptions<C>> {
 	/**
 	 * Create a new instance of a Router.
 	 * @param options Options to use during creation.
 	 */
-	(options?: RouterOptions): Router;
+	(options?: RouterOptions<Context>): Router<Context>;
+	<C>(options?: RouterOptions<C>): Router<C>;
 }
 
 interface PrivateState {
 	contextFactory: () => Context;
-	fallback?: (request: Request<any>) => void | Thenable<any>;
+	fallback?: (request: Request<Context, Parameters>) => void | Thenable<any>;
 	history?: History;
-	routes: Route<Parameters>[];
+	routes: Route<Context, Parameters>[];
 	started?: boolean;
 }
 
-const privateStateMap = new WeakMap<Router, PrivateState>();
+const privateStateMap = new WeakMap<Router<Context>, PrivateState>();
 
 // istanbul ignore next
 const noop = () => {};
@@ -206,8 +207,8 @@ function createDeferral() {
 	return { cancel, promise, resume };
 }
 
-function reportError(router: Router, context: Context, path: string, error: any) {
-	router.emit<ErrorEvent>({
+function reportError(router: Router<Context>, context: Context, path: string, error: any) {
+	router.emit<ErrorEvent<Context>>({
 		context,
 		error,
 		path,
@@ -216,7 +217,7 @@ function reportError(router: Router, context: Context, path: string, error: any)
 	});
 }
 
-function catchRejection(router: Router, context: Context, path: string, thenable: void | Thenable<any>) {
+function catchRejection(router: Router<Context>, context: Context, path: string, thenable: void | Thenable<any>) {
 	if (thenable) {
 		Promise.resolve(thenable).catch((error) => {
 			reportError(router, context, path, error);
@@ -224,9 +225,9 @@ function catchRejection(router: Router, context: Context, path: string, thenable
 	}
 }
 
-const createRouter: RouterFactory = compose.mixin(createEvented, {
+const createRouter: RouterFactory<Context> = compose.mixin(createEvented, {
 	mixin: {
-		append(this: Router, add: Route<Parameters> | Route<Parameters>[]) {
+		append(this: Router<Context>, add: Route<Context, Parameters> | Route<Context, Parameters>[]) {
 			const { routes } = privateStateMap.get(this);
 			if (Array.isArray(add)) {
 				for (const route of add) {
@@ -238,7 +239,7 @@ const createRouter: RouterFactory = compose.mixin(createEvented, {
 			}
 		},
 
-		dispatch(this: Router, context: Context, path: string): Task<DispatchResult> {
+		dispatch(this: Router<Context>, context: Context, path: string): Task<DispatchResult> {
 			let canceled = false;
 			const cancel = () => {
 				canceled = true;
@@ -277,7 +278,7 @@ const createRouter: RouterFactory = compose.mixin(createEvented, {
 
 						const { fallback, routes } = privateStateMap.get(this);
 						let redirect: undefined | string;
-						const dispatched = routes.some((route: Route<Parameters>) => {
+						const dispatched = routes.some((route: Route<Context, Parameters>) => {
 							const result = route.select(context, segments, trailingSlash, searchParams);
 							if (typeof result === 'string') {
 								redirect = result;
@@ -317,7 +318,7 @@ const createRouter: RouterFactory = compose.mixin(createEvented, {
 			}, cancel);
 		},
 
-		start(this: Router, { dispatchCurrent }: StartOptions = { dispatchCurrent: true }): PausableHandle {
+		start(this: Router<Context>, { dispatchCurrent }: StartOptions = { dispatchCurrent: true }): PausableHandle {
 			const state = privateStateMap.get(this);
 			if (state.started) {
 				throw new Error('start can only be called once');
@@ -357,14 +358,14 @@ const createRouter: RouterFactory = compose.mixin(createEvented, {
 			return listener;
 		}
 	},
-	initialize(instance: Router, { context, fallback, history }: RouterOptions = {}) {
-		let contextFactory: () => Context;
+	initialize<C extends Context>(instance: Router<C>, { context, fallback, history }: RouterOptions<C> = {}) {
+		let contextFactory: () => C;
 		if (typeof context === 'function') {
 			contextFactory = context;
 		}
 		else if (typeof context === 'undefined') {
 			contextFactory = () => {
-				return {};
+				return {} as C;
 			};
 		}
 		else {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -22,11 +22,11 @@ export interface Parameters {
 /**
  * Describes the object passed to various route handlers.
  */
-export interface Request<P extends Parameters> {
+export interface Request<C extends Context, P extends Parameters> {
 	/**
 	 * The dispatch context.
 	 */
-	context: Context;
+	context: C;
 
 	/**
 	 * The extracted parameters.

--- a/tests/unit/createRoute.ts
+++ b/tests/unit/createRoute.ts
@@ -3,9 +3,7 @@ import { suite, test } from 'intern!tdd';
 import * as assert from 'intern/chai!assert';
 
 import createRoute from '../../src/createRoute';
-import { DefaultParameters, Context, Request, Parameters } from '../../src/interfaces';
-
-interface R extends Request<Parameters> {};
+import { DefaultParameters, Context, Parameters } from '../../src/interfaces';
 
 suite('createRoute', () => {
 	test('can create route without options', () => {
@@ -29,7 +27,7 @@ suite('createRoute', () => {
 		const context: Context = {};
 		let received: Context = <any> undefined;
 		const route = createRoute({
-			guard ({ context }: R) {
+			guard ({ context }) {
 				received = context;
 				return true;
 			}
@@ -185,7 +183,7 @@ suite('createRoute', () => {
 		let received: Parameters = <any> undefined;
 		const route = createRoute<DefaultParameters>({
 			path: '/{foo}/{bar}?{baz}&{qux}',
-			guard ({ params }: R) {
+			guard ({ params }) {
 				received = params;
 				return true;
 			}

--- a/tests/unit/createRoute.ts
+++ b/tests/unit/createRoute.ts
@@ -3,7 +3,7 @@ import { suite, test } from 'intern!tdd';
 import * as assert from 'intern/chai!assert';
 
 import createRoute, { Route } from '../../src/createRoute';
-import { DefaultParameters, Context as C, Request, Parameters } from '../../src/interfaces';
+import { DefaultParameters, Context, Request, Parameters } from '../../src/interfaces';
 
 interface R extends Request<Parameters> {};
 
@@ -21,13 +21,13 @@ suite('createRoute', () => {
 			}
 		});
 
-		const selections = route.select({} as C, [], false, new UrlSearchParams());
+		const selections = route.select({} as Context, [], false, new UrlSearchParams());
 		assert.lengthOf(selections, 0);
 	});
 
 	test('guard() receives the context', () => {
-		const context: C = {};
-		let received: C = <any> undefined;
+		const context: Context = {};
+		let received: Context = <any> undefined;
 		const route = createRoute({
 			guard ({ context }: R) {
 				received = context;
@@ -62,7 +62,7 @@ suite('createRoute', () => {
 			path: '/{foo}/{bar}?{baz}&{qux}'
 		});
 
-		const result = route.select({} as C, ['quux', 'corge'], false, new UrlSearchParams('baz=grault&qux=garply'));
+		const result = route.select({} as Context, ['quux', 'corge'], false, new UrlSearchParams('baz=grault&qux=garply'));
 		if (typeof result === 'string') {
 			throw new TypeError('Unexpected result');
 		}
@@ -81,7 +81,7 @@ suite('createRoute', () => {
 			path: '/{foo}/{bar}?{baz}&{qux}'
 		});
 
-		const result = route.select({} as C, ['quux', 'corge'], false, new UrlSearchParams('baz=grault'));
+		const result = route.select({} as Context, ['quux', 'corge'], false, new UrlSearchParams('baz=grault'));
 		if (typeof result === 'string') {
 			throw new TypeError('Unexpected result');
 		}
@@ -99,7 +99,7 @@ suite('createRoute', () => {
 			path: '/{foo}/{bar}?{baz}&{qux}'
 		});
 
-		const result = route.select({} as C, ['quux', 'corge'], false, new UrlSearchParams('baz=grault&baz=garply'));
+		const result = route.select({} as Context, ['quux', 'corge'], false, new UrlSearchParams('baz=grault&baz=garply'));
 		if (typeof result === 'string') {
 			throw new TypeError('Unexpected result');
 		}
@@ -190,7 +190,7 @@ suite('createRoute', () => {
 				return true;
 			}
 		});
-		route.select({} as C, ['quux', 'corge'], false, new UrlSearchParams('baz=grault&qux=garply'));
+		route.select({} as Context, ['quux', 'corge'], false, new UrlSearchParams('baz=grault&qux=garply'));
 		assert.deepEqual(received, {
 			foo: 'quux',
 			bar: 'corge',
@@ -215,7 +215,7 @@ suite('createRoute', () => {
 			}
 		});
 
-		const result = route.select({} as C, ['baz', 'qux'], false, new UrlSearchParams());
+		const result = route.select({} as Context, ['baz', 'qux'], false, new UrlSearchParams());
 		if (typeof result === 'string') {
 			throw new TypeError('Unexpected result');
 		}
@@ -242,7 +242,7 @@ suite('createRoute', () => {
 			}
 		});
 
-		const result = route.select({} as C, [], false, new UrlSearchParams('foo=baz&bar=qux&foo=BAZ'));
+		const result = route.select({} as Context, [], false, new UrlSearchParams('foo=baz&bar=qux&foo=BAZ'));
 		if (typeof result === 'string') {
 			throw new TypeError('Unexpected result');
 		}
@@ -273,13 +273,13 @@ suite('createRoute', () => {
 			}
 		});
 
-		const selections = route.select({} as C, ['foo'], false, new UrlSearchParams());
+		const selections = route.select({} as Context, ['foo'], false, new UrlSearchParams());
 		assert.lengthOf(selections, 0);
 	});
 
 	test('without a path, is selected for zero segments', () => {
 		const route = createRoute();
-		const selections = route.select({} as C, [], false, new UrlSearchParams());
+		const selections = route.select({} as Context, [], false, new UrlSearchParams());
 		if (typeof selections === 'string') {
 			throw new TypeError('Unexpected result');
 		}
@@ -290,13 +290,13 @@ suite('createRoute', () => {
 
 	test('without a path or nested routes, is not selected for segments', () => {
 		const route = createRoute();
-		const selections = route.select({} as C, ['foo'], false, new UrlSearchParams());
+		const selections = route.select({} as Context, ['foo'], false, new UrlSearchParams());
 		assert.lengthOf(selections, 0);
 	});
 
 	test('with a path, is selected if segments match', () => {
 		const route = createRoute({ path: '/foo/bar' });
-		const selections = route.select({} as C, ['foo', 'bar'], false, new UrlSearchParams());
+		const selections = route.select({} as Context, ['foo', 'bar'], false, new UrlSearchParams());
 		if (typeof selections === 'string') {
 			throw new TypeError('Unexpected result');
 		}
@@ -308,13 +308,13 @@ suite('createRoute', () => {
 	test('with a path, is not selected if segments do not match', () => {
 		{
 			const route = createRoute({ path: '/foo/bar' });
-			const selections = route.select({} as C, ['baz', 'qux'], false, new UrlSearchParams());
+			const selections = route.select({} as Context, ['baz', 'qux'], false, new UrlSearchParams());
 			assert.lengthOf(selections, 0);
 		}
 
 		{
 			const route = createRoute({ path: '/foo/bar' });
-			const selections = route.select({} as C, ['foo'], false, new UrlSearchParams());
+			const selections = route.select({} as Context, ['foo'], false, new UrlSearchParams());
 			assert.lengthOf(selections, 0);
 		}
 	});
@@ -326,7 +326,7 @@ suite('createRoute', () => {
 		root.append(deep);
 		deep.append(deeper);
 
-		const selections = root.select({} as C, ['foo', 'bar', 'baz'], false, new UrlSearchParams());
+		const selections = root.select({} as Context, ['foo', 'bar', 'baz'], false, new UrlSearchParams());
 		if (typeof selections === 'string') {
 			throw new TypeError('Unexpected result');
 		}
@@ -348,7 +348,7 @@ suite('createRoute', () => {
 			root.append(altDeep);
 			deep.append(deeper);
 
-			const selections = root.select({} as C, ['foo', 'bar', 'baz'], false, new UrlSearchParams());
+			const selections = root.select({} as Context, ['foo', 'bar', 'baz'], false, new UrlSearchParams());
 			assert.lengthOf(selections, 3);
 		}
 
@@ -361,7 +361,7 @@ suite('createRoute', () => {
 			root.append(deep);
 			deep.append(deeper);
 
-			const selections = root.select({} as C, ['foo', 'bar', 'baz'], false, new UrlSearchParams());
+			const selections = root.select({} as Context, ['foo', 'bar', 'baz'], false, new UrlSearchParams());
 			assert.lengthOf(selections, 2);
 		}
 	});
@@ -373,7 +373,7 @@ suite('createRoute', () => {
 		root.append(deep);
 		deep.append(deeper);
 
-		const selections = root.select({} as C, ['foo', 'bar', 'baz'], false, new UrlSearchParams());
+		const selections = root.select({} as Context, ['foo', 'bar', 'baz'], false, new UrlSearchParams());
 		assert.lengthOf(selections, 3);
 	});
 
@@ -385,7 +385,7 @@ suite('createRoute', () => {
 			root.append(deep);
 			deep.append(deeper);
 
-			const selections = root.select({} as C, ['foo', 'bar', 'baz'], withSlash, new UrlSearchParams());
+			const selections = root.select({} as Context, ['foo', 'bar', 'baz'], withSlash, new UrlSearchParams());
 			assert.lengthOf(selections, withSlash ? 3 : 0, `there is ${withSlash ? 'a' : 'no'} trailing slash when selecting`);
 		});
 	});
@@ -398,7 +398,7 @@ suite('createRoute', () => {
 			root.append(deep);
 			deep.append(deeper);
 
-			const selections = root.select({} as C, ['foo', 'bar', 'baz'], withSlash, new UrlSearchParams());
+			const selections = root.select({} as Context, ['foo', 'bar', 'baz'], withSlash, new UrlSearchParams());
 			assert.lengthOf(selections, withSlash ? 0 : 3, `there is ${withSlash ? 'a' : 'no'} trailing slash when selecting`);
 		});
 	});
@@ -414,7 +414,7 @@ suite('createRoute', () => {
 			root.append(deep);
 			deep.append(deeper);
 
-			const selections = root.select({} as C, ['foo', 'bar', 'baz'], withSlash, new UrlSearchParams());
+			const selections = root.select({} as Context, ['foo', 'bar', 'baz'], withSlash, new UrlSearchParams());
 			assert.lengthOf(selections, 3, `there is ${withSlash ? 'a' : 'no'} trailing slash when selecting`);
 		});
 	});
@@ -424,7 +424,7 @@ suite('createRoute', () => {
 		const deep = createRoute({ path: '/bar' });
 		root.append(deep);
 
-		const selections = root.select({} as C, ['foo', 'bar', 'baz'], false, new UrlSearchParams());
+		const selections = root.select({} as Context, ['foo', 'bar', 'baz'], false, new UrlSearchParams());
 		assert.lengthOf(selections, 0);
 	});
 
@@ -438,7 +438,7 @@ suite('createRoute', () => {
 		});
 		root.append(deep);
 
-		assert.strictEqual(root.select({} as C, ['root', 'deep'], false, new UrlSearchParams()), '/shallow');
+		assert.strictEqual(root.select({} as Context, ['root', 'deep'], false, new UrlSearchParams()), '/shallow');
 	});
 
 	test('guards can request redirects by returning empty path strings', () => {
@@ -451,7 +451,7 @@ suite('createRoute', () => {
 		});
 		root.append(deep);
 
-		assert.strictEqual(root.select({} as C, ['root', 'deep'], false, new UrlSearchParams()), '');
+		assert.strictEqual(root.select({} as Context, ['root', 'deep'], false, new UrlSearchParams()), '');
 	});
 
 	test('extracts path parameters for each nested route', () => {
@@ -461,7 +461,7 @@ suite('createRoute', () => {
 		root.append(deep);
 		deep.append(deeper);
 
-		const selections = root.select({} as C, ['foo', 'root', 'bar', 'deep', 'baz', 'deeper'], false, new UrlSearchParams());
+		const selections = root.select({} as Context, ['foo', 'root', 'bar', 'deep', 'baz', 'deeper'], false, new UrlSearchParams());
 		if (typeof selections === 'string') {
 			throw new TypeError('Unexpected result');
 		}
@@ -492,15 +492,15 @@ suite('createRoute', () => {
 		root.append(deep);
 
 		called = [];
-		root.select({} as C, ['root'], false, new UrlSearchParams());
+		root.select({} as Context, ['root'], false, new UrlSearchParams());
 		assert.deepEqual(called, ['root'], '/root');
 
 		called = [];
-		root.select({} as C, ['root', 'deep'], false, new UrlSearchParams());
+		root.select({} as Context, ['root', 'deep'], false, new UrlSearchParams());
 		assert.deepEqual(called, ['root', 'deep'], '/root/deep');
 
 		called = [];
-		root.select({} as C, ['root', 'deep', 'deeper'], false, new UrlSearchParams());
+		root.select({} as Context, ['root', 'deep', 'deeper'], false, new UrlSearchParams());
 		assert.deepEqual(called, ['root'], '/root/deep/deeper (deep isn’t selected because it doesn’t have a fallback)');
 	});
 
@@ -510,7 +510,7 @@ suite('createRoute', () => {
 		const altDeep = createRoute({ path: '/bar/baz' });
 		root.append([altDeep, deep]);
 
-		const selections = root.select({} as C, ['foo', 'bar', 'baz'], false, new UrlSearchParams());
+		const selections = root.select({} as Context, ['foo', 'bar', 'baz'], false, new UrlSearchParams());
 		assert.lengthOf(selections, 2);
 	});
 });

--- a/tests/unit/createRoute.ts
+++ b/tests/unit/createRoute.ts
@@ -511,4 +511,22 @@ suite('createRoute', () => {
 		const selections = root.select({} as Context, ['foo', 'bar', 'baz'], false, new UrlSearchParams());
 		assert.lengthOf(selections, 2);
 	});
+
+	// This test is mostly there to verify the typings at compile time.
+	test('createRoute takes a Context type', () => {
+		interface Refined extends Context {
+			refined: boolean;
+		}
+		const route = createRoute<Refined, any>({
+			path: '/foo',
+			exec({ context }) {
+				assert.isTrue(context.refined);
+			}
+		});
+		const context: Refined = { refined: true };
+		const result = route.select(context, ['foo'], false, new UrlSearchParams());
+		if (Array.isArray(result)) {
+			result[0].handler({ context, params: {} });
+		}
+	});
 });

--- a/tests/unit/createRoute.ts
+++ b/tests/unit/createRoute.ts
@@ -2,7 +2,7 @@ import UrlSearchParams from 'dojo-core/UrlSearchParams';
 import { suite, test } from 'intern!tdd';
 import * as assert from 'intern/chai!assert';
 
-import createRoute, { Route } from '../../src/createRoute';
+import createRoute from '../../src/createRoute';
 import { DefaultParameters, Context, Request, Parameters } from '../../src/interfaces';
 
 interface R extends Request<Parameters> {};
@@ -58,7 +58,7 @@ suite('createRoute', () => {
 	});
 
 	test('path parameters are extracted', () => {
-		const route = <Route<DefaultParameters>> createRoute({
+		const route = createRoute<DefaultParameters>({
 			path: '/{foo}/{bar}?{baz}&{qux}'
 		});
 
@@ -77,7 +77,7 @@ suite('createRoute', () => {
 	});
 
 	test('search parameters are optional', () => {
-		const route = <Route<DefaultParameters>> createRoute({
+		const route = createRoute<DefaultParameters>({
 			path: '/{foo}/{bar}?{baz}&{qux}'
 		});
 
@@ -95,7 +95,7 @@ suite('createRoute', () => {
 	});
 
 	test('only the first search parameter value is extracted', () => {
-		const route = <Route<DefaultParameters>> createRoute({
+		const route = createRoute<DefaultParameters>({
 			path: '/{foo}/{bar}?{baz}&{qux}'
 		});
 
@@ -183,7 +183,7 @@ suite('createRoute', () => {
 
 	test('guard() receives the extracted parameters', () => {
 		let received: Parameters = <any> undefined;
-		const route = <Route<DefaultParameters>> createRoute({
+		const route = createRoute<DefaultParameters>({
 			path: '/{foo}/{bar}?{baz}&{qux}',
 			guard ({ params }: R) {
 				received = params;
@@ -204,7 +204,7 @@ suite('createRoute', () => {
 			upper: string;
 			barIsQux: boolean;
 		}
-		const route = <Route<Customized>> createRoute({
+		const route = createRoute<Customized>({
 			path: '/{foo}/{bar}',
 			params (fromPath) {
 				const [foo, bar] = fromPath;
@@ -232,11 +232,11 @@ suite('createRoute', () => {
 			fooArr: string[];
 			barIsQux: boolean;
 		}
-		const route = <Route<Customized>> createRoute({
+		const route = createRoute<Customized>({
 			path: '/?{foo}&{bar}',
 			params (fromPath, searchParams) {
 				return {
-					fooArr: searchParams.getAll('foo'),
+					fooArr: searchParams.getAll('foo') || [],
 					barIsQux: searchParams.get('bar') === 'qux'
 				};
 			}

--- a/tests/unit/createRouter.ts
+++ b/tests/unit/createRouter.ts
@@ -670,7 +670,7 @@ suite('createRouter', () => {
 		let context: Context = {};
 		let dispatch = () => new Promise(() => {});
 		let fallback: any = null;
-		let events: ErrorEvent[] = [];
+		let events: ErrorEvent<Context>[] = [];
 		const path = '/foo/bar';
 		let router = createRouter();
 
@@ -792,5 +792,26 @@ suite('createRouter', () => {
 			fallback = () => { return Promise.reject(error); };
 			return verify(dispatch(), error);
 		});
+	});
+
+	// This test is mostly there to verify the typings at compile time.
+	test('createRouter takes a Context type', () => {
+		interface Refined extends Context {
+			refined: boolean;
+		}
+		const router = createRouter<Refined>({
+			context: { refined: true },
+			fallback({ context }) {
+				assert.isTrue(context.refined);
+			}
+		});
+		router.append(createRoute<Refined, any>({
+			path: '/foo',
+			exec({ context }) {
+				assert.isTrue(context.refined);
+			}
+		}));
+		router.dispatch({ refined: true }, '/foo');
+		router.dispatch({ refined: true }, '/bar');
 	});
 });

--- a/tests/unit/createRouter.ts
+++ b/tests/unit/createRouter.ts
@@ -7,13 +7,13 @@ import { stub, spy } from 'sinon';
 import createRoute from '../../src/createRoute';
 import createRouter, { DispatchResult, ErrorEvent, NavigationStartEvent } from '../../src/createRouter';
 import createMemoryHistory from '../../src/history/createMemoryHistory';
-import { DefaultParameters, Context as C, Request, Parameters } from '../../src/interfaces';
+import { DefaultParameters, Context, Request, Parameters } from '../../src/interfaces';
 
 interface R extends Request<Parameters> {};
 
 suite('createRouter', () => {
 	test('dispatch resolves to unsuccessful result if no route was executed', () => {
-		return createRouter().dispatch({} as C, '/').then(result => {
+		return createRouter().dispatch({} as Context, '/').then(result => {
 			assert.deepEqual(result, { success: false });
 		});
 	});
@@ -21,7 +21,7 @@ suite('createRouter', () => {
 	test('dispatch resolves to successful result if a route was executed', () => {
 		const router = createRouter();
 		router.append(createRoute());
-		return router.dispatch({} as C, '/').then(result => {
+		return router.dispatch({} as Context, '/').then(result => {
 			assert.deepEqual(result, { success: true });
 		});
 	});
@@ -30,7 +30,7 @@ suite('createRouter', () => {
 		const err = {};
 		const router = createRouter();
 		router.append(createRoute({ exec () { throw err; }}));
-		return router.dispatch({} as C, '/').then(() => {
+		return router.dispatch({} as Context, '/').then(() => {
 			assert.fail('Should not be called');
 		}, actual => {
 			assert.strictEqual(actual, err);
@@ -44,7 +44,7 @@ suite('createRouter', () => {
 			guard() { return '/bar'; }
 		}));
 
-		return router.dispatch({} as C, '/foo').then((result) => {
+		return router.dispatch({} as Context, '/foo').then((result) => {
 			assert.deepEqual(result, { redirect: '/bar', success: true });
 		});
 	});
@@ -56,7 +56,7 @@ suite('createRouter', () => {
 			guard() { return ''; }
 		}));
 
-		return router.dispatch({} as C, '/foo').then((result) => {
+		return router.dispatch({} as Context, '/foo').then((result) => {
 			assert.deepEqual(result, { redirect: '', success: true });
 		});
 	});
@@ -74,16 +74,16 @@ suite('createRouter', () => {
 			exec() { executed = true; }
 		}));
 
-		return router.dispatch({} as C, '/foo').then((result) => {
+		return router.dispatch({} as Context, '/foo').then((result) => {
 			assert.deepEqual(result, { redirect: '/bar', success: true });
 			assert.isFalse(executed);
 		});
 	});
 
 	test('dispatch executes selected routes, providing context and extracted parameters', () => {
-		const execs: { context: C, params: Parameters }[] = [];
+		const execs: { context: Context, params: Parameters }[] = [];
 
-		const context = {} as C;
+		const context = {} as Context;
 		const router = createRouter();
 		const root = createRoute({
 			path: '/{foo}',
@@ -110,9 +110,9 @@ suite('createRouter', () => {
 	});
 
 	test('dispatch calls index() on the final selected route, providing context and extracted parameters', () => {
-		const calls: { method: string, context: C, params: Parameters }[] = [];
+		const calls: { method: string, context: Context, params: Parameters }[] = [];
 
-		const context = {} as C;
+		const context = {} as Context;
 		const router = createRouter();
 		const root = createRoute({
 			path: '/{foo}',
@@ -144,9 +144,9 @@ suite('createRouter', () => {
 	});
 
 	test('dispatch calls fallback() on the deepest matching route, providing context and extracted parameters', () => {
-		const calls: { method: string, context: C, params: Parameters }[] = [];
+		const calls: { method: string, context: Context, params: Parameters }[] = [];
 
-		const context = {} as C;
+		const context = {} as Context;
 		const router = createRouter();
 		const root = createRoute({
 			path: '/{foo}',
@@ -185,7 +185,7 @@ suite('createRouter', () => {
 			}
 		}));
 
-		return router.dispatch({} as C, '/foo').then(() => {
+		return router.dispatch({} as Context, '/foo').then(() => {
 			assert.deepEqual(order, ['first', 'second']);
 		});
 	});
@@ -198,7 +198,7 @@ suite('createRouter', () => {
 			received = event;
 		});
 
-		router.dispatch({} as C, '/foo');
+		router.dispatch({} as Context, '/foo');
 		assert.equal(received.path, '/foo');
 		assert.isNull(received.target);
 	});
@@ -210,7 +210,7 @@ suite('createRouter', () => {
 			event.cancel();
 		});
 
-		return router.dispatch({} as C, '/foo').then(({ success: d }) => {
+		return router.dispatch({} as Context, '/foo').then(({ success: d }) => {
 			assert.isFalse(d);
 		});
 	});
@@ -223,7 +223,7 @@ suite('createRouter', () => {
 			Promise.resolve().then(cancel);
 		});
 
-		return router.dispatch({} as C, '/foo').then(({ success: d }) => {
+		return router.dispatch({} as Context, '/foo').then(({ success: d }) => {
 			assert.isFalse(d);
 		});
 	});
@@ -236,7 +236,7 @@ suite('createRouter', () => {
 			Promise.resolve().then(resume);
 		});
 
-		return router.dispatch({} as C, '/foo').then(({ success: d }) => {
+		return router.dispatch({} as Context, '/foo').then(({ success: d }) => {
 			assert.isTrue(d);
 		});
 	});
@@ -256,7 +256,7 @@ suite('createRouter', () => {
 		});
 
 		let dispatched: boolean | undefined = false;
-		router.dispatch({} as C, '/foo').then(({ success: d }) => {
+		router.dispatch({} as Context, '/foo').then(({ success: d }) => {
 			dispatched = d;
 		});
 
@@ -289,7 +289,7 @@ suite('createRouter', () => {
 			resume = event.defer().resume;
 		});
 
-		const task = router.dispatch({} as C, '/foo');
+		const task = router.dispatch({} as Context, '/foo');
 		task.cancel();
 		resume();
 
@@ -307,7 +307,7 @@ suite('createRouter', () => {
 			}
 		});
 
-		const context = {} as C;
+		const context = {} as Context;
 		return router.dispatch(context, '/foo').then(({ success: d }) => {
 			assert.isTrue(d);
 			assert.ok(received);
@@ -336,7 +336,7 @@ suite('createRouter', () => {
 			})
 		]);
 
-		return router.dispatch({} as C, '/foo').then(() => {
+		return router.dispatch({} as Context, '/foo').then(() => {
 			assert.deepEqual(order, ['first', 'second']);
 		});
 	});
@@ -350,7 +350,7 @@ suite('createRouter', () => {
 		deep.append(deeper);
 		router.append(root);
 
-		return router.dispatch({} as C, 'foo/bar/baz').then(({ success: d }) => {
+		return router.dispatch({} as Context, 'foo/bar/baz').then(({ success: d }) => {
 			assert.isTrue(d);
 		});
 	});
@@ -365,7 +365,7 @@ suite('createRouter', () => {
 			deep.append(deeper);
 			router.append(root);
 
-			return router.dispatch({} as C, `foo/bar/baz${withSlash ? '/' : ''}`).then(({ success: d }) => {
+			return router.dispatch({} as Context, `foo/bar/baz${withSlash ? '/' : ''}`).then(({ success: d }) => {
 				assert.isTrue(d === withSlash, `there is ${withSlash ? 'a' : 'no'} trailing slash`);
 			});
 		}));
@@ -381,7 +381,7 @@ suite('createRouter', () => {
 			deep.append(deeper);
 			router.append(root);
 
-			return router.dispatch({} as C, `foo/bar/baz${withSlash ? '/' : ''}`).then(({ success: d }) => {
+			return router.dispatch({} as Context, `foo/bar/baz${withSlash ? '/' : ''}`).then(({ success: d }) => {
 				assert.isTrue(d !== withSlash, `there is ${withSlash ? 'a' : 'no'} trailing slash`);
 			});
 		}));
@@ -400,7 +400,7 @@ suite('createRouter', () => {
 			deep.append(deeper);
 			router.append(root);
 
-			return router.dispatch({} as C, `foo/bar/baz${withSlash ? '/' : ''}`).then(({ success: d }) => {
+			return router.dispatch({} as Context, `foo/bar/baz${withSlash ? '/' : ''}`).then(({ success: d }) => {
 				assert.isTrue(d, `there is ${withSlash ? 'a' : 'no'} trailing slash`);
 			});
 		}));
@@ -410,7 +410,7 @@ suite('createRouter', () => {
 		const router = createRouter();
 		router.append(createRoute({ path: '/foo' }));
 
-		return router.dispatch({} as C, '/foo?bar').then(({ success: d }) => {
+		return router.dispatch({} as Context, '/foo?bar').then(({ success: d }) => {
 			assert.isTrue(d);
 		});
 	});
@@ -419,7 +419,7 @@ suite('createRouter', () => {
 		const router = createRouter();
 		router.append(createRoute({ path: '/foo' }));
 
-		return router.dispatch({} as C, '/foo#bar').then(({ success: d }) => {
+		return router.dispatch({} as Context, '/foo#bar').then(({ success: d }) => {
 			assert.isTrue(d);
 		});
 	});
@@ -428,10 +428,10 @@ suite('createRouter', () => {
 		const router = createRouter();
 		router.append(createRoute({ path: '/foo' }));
 
-		return router.dispatch({} as C, '/foo?bar#baz').then(({ success: d }) => {
+		return router.dispatch({} as Context, '/foo?bar#baz').then(({ success: d }) => {
 			assert.isTrue(d, '/foo?bar#baz');
 
-			return router.dispatch({} as C, '/foo#bar?baz');
+			return router.dispatch({} as Context, '/foo#bar?baz');
 		}).then(({ success: d }) => {
 			assert.isTrue(d);
 		});
@@ -441,7 +441,7 @@ suite('createRouter', () => {
 		const router = createRouter();
 		router.append(createRoute({ path: '/foo/bar' }));
 
-		return router.dispatch({} as C, '//foo///bar').then(({ success: d }) => {
+		return router.dispatch({} as Context, '//foo///bar').then(({ success: d }) => {
 			assert.isTrue(d);
 		});
 	});
@@ -457,16 +457,16 @@ suite('createRouter', () => {
 			}
 		}));
 
-		return router.dispatch({} as C, '/foo?bar=1&baz=2').then(() => {
+		return router.dispatch({} as Context, '/foo?bar=1&baz=2').then(() => {
 			assert.deepEqual(extracted, {bar: '1', baz: '2'});
 
 			extracted = {};
-			return router.dispatch({} as C, '/foo?bar=3#baz=4');
+			return router.dispatch({} as Context, '/foo?bar=3#baz=4');
 		}).then(() => {
 			assert.deepEqual(extracted, {bar: '3'});
 
 			extracted = {};
-			return router.dispatch({} as C, '/foo#bar=5?baz=6');
+			return router.dispatch({} as Context, '/foo#bar=5?baz=6');
 		}).then(() => {
 			assert.deepEqual(extracted, {});
 		});
@@ -669,7 +669,7 @@ suite('createRouter', () => {
 	});
 
 	suite('dispatch errors are emitted', () => {
-		let context: C = {};
+		let context: Context = {};
 		let dispatch = () => new Promise(() => {});
 		let fallback: any = null;
 		let events: ErrorEvent[] = [];

--- a/tests/unit/createRouter.ts
+++ b/tests/unit/createRouter.ts
@@ -9,8 +9,6 @@ import createRouter, { DispatchResult, ErrorEvent, NavigationStartEvent } from '
 import createMemoryHistory from '../../src/history/createMemoryHistory';
 import { DefaultParameters, Context, Request, Parameters } from '../../src/interfaces';
 
-interface R extends Request<Parameters> {};
-
 suite('createRouter', () => {
 	test('dispatch resolves to unsuccessful result if no route was executed', () => {
 		return createRouter().dispatch({} as Context, '/').then(result => {
@@ -299,7 +297,7 @@ suite('createRouter', () => {
 	});
 
 	test('router can be created with a fallback route', () => {
-		let received: R;
+		let received: Request<Context, Parameters>;
 
 		const router = createRouter({
 			fallback (request) {


### PR DESCRIPTION
It's all in the last commit:

createRouter() can now be passed a context type using generics. This
type propagates to the error event and dispatch() function.

Similarly createRoute() now supports a variant where it can be passed
context and parameters generics. This propagates to the request object
passed to the various handlers.

Fixes #34.
