### PR TITLE
Pass Context argument to Router type

### DIFF
--- a/src/createRouter.ts
+++ b/src/createRouter.ts
@@ -55,7 +55,7 @@ export interface NavigationStartEvent extends TargettedEventObject {
 	/**
 	 * The router that emitted this event.
 	 */
-	target: Router;
+	target: Router<Context>;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #45 which broke due to #41.
