### PR TITLE
Consider dispatch unsuccessful if router fallback was invoked

### DIFF
--- a/src/createRouter.ts
+++ b/src/createRouter.ts
@@ -302,7 +302,7 @@ const createRouter: RouterFactory<Context> = compose.mixin(createEvented, {
 
 						if (!dispatched && fallback) {
 							catchRejection(this, context, path, fallback({ context, params: {} }));
-							return { success: true };
+							return { success: false };
 						}
 
 						const result: DispatchResult = { success: dispatched };

--- a/tests/unit/createRouter.ts
+++ b/tests/unit/createRouter.ts
@@ -307,7 +307,7 @@ suite('createRouter', () => {
 
 		const context = {} as Context;
 		return router.dispatch(context, '/foo').then(({ success: d }) => {
-			assert.isTrue(d);
+			assert.isFalse(d);
 			assert.ok(received);
 			assert.strictEqual(received.context, context);
 			assert.deepEqual(received.params, {});


### PR DESCRIPTION
No route was selected, so the dispatch cannot be considered successful.
