### PR TITLE
Implement link generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,49 @@ router.append(createRoute({
 router.dispatch(context, '//foo///bar'); // Selects the /foo/bar route
 ```
 
+### Link generation
+
+The router can generate links for a given route:
+
+```ts
+const router = createRouter();
+const blog = createRoute({ path: '/blog' });
+router.append(blog);
+
+router.link(blog) === '/blog';
+```
+
+This also works with parameters:
+
+```ts
+const show = createRoute({ path: '/{id}' });
+blog.append(show);
+
+router.link(show, { id: '5' }) === '/blog/5';
+```
+
+And query parameters:
+
+```ts
+const show = createRoute({ path: '/{id}?{highlight}' });
+blog.append(show);
+
+router.link(show, { id: '5', highlight: '40' }) === '/blog/5?highlight=40';
+router.link(show, { id: '5', highlight: [ '40' ] }) === '/blog/5?highlight=40';
+router.link(show, { id: '5', highlight: [ '40', '55' ] }) === '/blog/5?highlight=40&highlight=55';
+```
+
+Note that if routes share the same parameter name they'll receive the same value:
+
+```ts
+const category = createRoute({ path: '/categories/{id}' });
+const post = createRoute({ path: '/posts/{id}' });
+blog.append(category);
+category.append(post);
+
+router.link(post, { id: '5' }) === '/blog/categories/5/posts/5';
+```
+
 ### History management
 
 This library ships with three history managers. They share the same interface but have different ways of monitoring and changing the navigation state.
@@ -529,7 +572,7 @@ const history = createMemoryHistory();
 
 The `createMemoryHistory()` factory accepts a `path` option. It defaults to the empty string.
 
-#### Automatically observing a history manager
+### Automatic routing and clever linking through `start()`
 
 You could manually wire a history manager's `change` event to a `Router#dispatch()`, but that's a bit cumbersome. Instead you can provide the history manager when creating the router, and then use the `start()` method to make the router observe the history manager:
 
@@ -567,6 +610,29 @@ const router = createRouter({
 	history: createStateHistory()
 });
 ```
+
+`link()` can use the currently selected routes when generating a new link. For instance given this router:
+
+```ts
+const history = createStateHistory();
+const router = createRouter({ history });
+
+const blog = createRoute({ path: '/blog' });
+const show = createRoute({ path: '/{id}' });
+const edit = createRoute({ path: '/edit' });
+
+router.append(blog);
+blog.append(show);
+show.append(edit);
+```
+
+If the current URL is `/blog/5`, then you can generate a link for the `edit` route without having to provide any parameters:
+
+```ts
+router.link(edit) === '/blog/5/edit';
+```
+
+Calling `dispatch()` directly will prevent the router from tracking selected routes. They'll also be unavailable after a redirect has been requested, before new routes have been selected.
 
 ### Capturing errors
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ router.append([
 ]);
 ```
 
+Routes can only be appended to a router once.
+
 ### Dispatching paths
 
 The router doesn't track navigation events by itself. Changed paths need to be dispatched by application code. Context must be provided, this is made available to the matched routes.
@@ -146,6 +148,8 @@ posts.append([
 	createRoute({ path: 'other' })
 ]);
 ```
+
+Routes can only be appended to another route, or a router, once.
 
 Starting the path of a nested route with a leading slash will not make it absolute. The nested route's path will still be relative to that of the route it's appended to.
 

--- a/src/createRoute.ts
+++ b/src/createRoute.ts
@@ -32,13 +32,18 @@ export interface MatchResult<P> {
 }
 
 /**
+ * A request handler.
+ */
+export type Handler = (request: Request<Context, Parameters>) => void | Thenable<any>;
+
+/**
  * Describes the selection of a particular route.
  */
 export interface Selection {
 	/**
 	 * Which handler should be called when the route is executed.
 	 */
-	handler: (request: Request<Context, Parameters>) => void | Thenable<any>;
+	handler: Handler;
 
 	/**
 	 * The extracted parameters.
@@ -162,10 +167,10 @@ interface PrivateState {
 	trailingSlashMustMatch: boolean;
 
 	computeParams<P extends Parameters>(fromPathname: string[], searchParams: UrlSearchParams): null | P;
-	exec?(request: Request<Context, Parameters>): void | Thenable<any>;
-	fallback?(request: Request<Context, Parameters>): void | Thenable<any>;
+	exec?: Handler;
+	fallback?: Handler;
 	guard?(request: Request<Context, Parameters>): string | boolean;
-	index?(request: Request<Context, Parameters>): void | Thenable<any>;
+	index?: Handler;
 }
 
 const privateStateMap = new WeakMap<Route<Context, Parameters>, PrivateState>();

--- a/src/createRoute.ts
+++ b/src/createRoute.ts
@@ -12,6 +12,12 @@ import {
 } from './lib/path';
 
 /**
+ * Hash object where keys are parameter names and keys are arrays of one or more
+ * parameter values.
+ */
+export type SearchParams = Hash<string[]>;
+
+/**
  * Describes whether a route matched.
  */
 export interface MatchResult<P> {
@@ -228,13 +234,13 @@ const createRoute: RouteFactory<Context, Parameters> =
 			}
 
 			// Only extract the search params defined in the route's path.
-			const knownSearchParams = path.searchParameters.reduce((list, name) => {
+			const knownSearchParams = path.searchParameters.reduce<SearchParams>((list, name) => {
 				const value = searchParams.getAll(name);
 				if (value !== undefined) {
 					list[name] = value;
 				}
 				return list;
-			}, {} as Hash<string[]>);
+			}, {});
 
 			const params = computeParams(result.values, new UrlSearchParams(knownSearchParams));
 			if (params === null) {

--- a/src/createRoute.ts
+++ b/src/createRoute.ts
@@ -101,6 +101,11 @@ export interface Route<C extends Context, P extends Parameters> {
 	readonly parent?: Route<Context, Parameters>;
 
 	/**
+	 * Frozen, deconstructed path object.
+	 */
+	readonly path: DeconstructedPath;
+
+	/**
 	 * Append one or more routes.
 	 *
 	 * A route can only appended to another route, or a router itself, once.
@@ -247,6 +252,10 @@ const createRoute: RouteFactory<Context, Parameters> =
 	compose({
 		get parent(this: Route<Context, Parameters>) {
 			return parentMap.get(this);
+		},
+
+		get path(this: Route<Context, Parameters>) {
+			return privateStateMap.get(this).path;
 		},
 
 		append(this: Route<Context, Parameters>, add: Route<Context, Parameters> | Route<Context, Parameters>[]) {

--- a/src/history/createHashHistory.ts
+++ b/src/history/createHashHistory.ts
@@ -45,6 +45,10 @@ const createHashHistory: HashHistoryFactory = compose.mixin(createEvented, {
 			return privateStateMap.get(this).current;
 		},
 
+		prefix(path: string) {
+			return `#${path}`;
+		},
+
 		set(this: HashHistory, path: string) {
 			const privateState = privateStateMap.get(this);
 			if (privateState.current === path) {
@@ -52,7 +56,7 @@ const createHashHistory: HashHistoryFactory = compose.mixin(createEvented, {
 			}
 
 			privateState.current = path;
-			privateState.browserLocation.hash = '#' + path;
+			privateState.browserLocation.hash = this.prefix(path);
 			this.emit({
 				type: 'change',
 				value: path
@@ -68,7 +72,7 @@ const createHashHistory: HashHistoryFactory = compose.mixin(createEvented, {
 			privateState.current = path;
 
 			const { pathname, search } = privateState.browserLocation;
-			privateState.browserLocation.replace(pathname + search + '#' + path);
+			privateState.browserLocation.replace(pathname + search + this.prefix(path));
 
 			this.emit({
 				type: 'change',

--- a/src/history/createMemoryHistory.ts
+++ b/src/history/createMemoryHistory.ts
@@ -40,6 +40,10 @@ const createMemoryHistory: MemoryHistoryFactory = compose.mixin(createEvented, {
 			return privateStateMap.get(this).current;
 		},
 
+		prefix(path: string) {
+			return path;
+		},
+
 		set(this: MemoryHistory, path: string) {
 			const privateState = privateStateMap.get(this);
 			if (privateState.current === path) {

--- a/src/history/interfaces.ts
+++ b/src/history/interfaces.ts
@@ -25,6 +25,11 @@ export interface HistoryMixin {
 	readonly current: string;
 
 	/**
+	 * Prefixes the value in order to create a path that can be used with a browser.
+	 */
+	prefix(path: string): string;
+
+	/**
 	 * Set the current value. If used with a browser implementation causes a new history entry
 	 * to be added. Fires the 'change' event.
 	 */

--- a/src/lib/path.ts
+++ b/src/lib/path.ts
@@ -215,7 +215,7 @@ export function deconstruct(path: string): DeconstructedPath {
 					searchParameters.push(name);
 				} else {
 					parameters.push(name);
-					expectedSegments.push({ name });
+					expectedSegments.push(Object.freeze({ name }));
 				}
 
 				break;
@@ -263,9 +263,14 @@ export function deconstruct(path: string): DeconstructedPath {
 					throw new TypeError(`Expected parameter in search component, got '${t}'`);
 				}
 
-				expectedSegments.push({ literal: t });
+				expectedSegments.push(Object.freeze({ literal: t }));
 		}
 	}
 
-	return { expectedSegments, parameters, searchParameters, trailingSlash };
+	return Object.freeze({
+		expectedSegments: Object.freeze(expectedSegments),
+		parameters: Object.freeze(parameters),
+		searchParameters: Object.freeze(searchParameters),
+		trailingSlash
+	});
 }

--- a/src/lib/path.ts
+++ b/src/lib/path.ts
@@ -130,7 +130,13 @@ export interface NamedSegment {
 
 export type Segment = LiteralSegment | NamedSegment;
 
-function isNamedSegment(segment: Segment): segment is NamedSegment {
+/**
+ * Determine whether the segment is a NamedSegment.
+ *
+ * @param segment The segment to be checked
+ * @return true if the segment is a NamedSegment, false otherwise
+ */
+export function isNamedSegment(segment: Segment): segment is NamedSegment {
 	return (<NamedSegment> segment).name !== undefined;
 }
 

--- a/src/lib/path.ts
+++ b/src/lib/path.ts
@@ -144,6 +144,11 @@ export interface DeconstructedPath {
 	expectedSegments: Segment[];
 
 	/**
+	 * Whether the pathname started with a slash.
+	 */
+	leadingSlash: boolean;
+
+	/**
 	 * Named path parameters, in the order that they occurred in the path.
 	 */
 	parameters: string[];
@@ -154,7 +159,7 @@ export interface DeconstructedPath {
 	searchParameters: string[];
 
 	/**
-	 * Whether the pathname ended with a trailing slash.
+	 * Whether the pathname ended with a slash.
 	 */
 	trailingSlash: boolean;
 }
@@ -171,6 +176,7 @@ export function deconstruct(path: string): DeconstructedPath {
 	let trailingSlash = false;
 
 	const tokens = path.split(/([/{}?&])/).filter(Boolean);
+	const leadingSlash = tokens[0] === '/';
 
 	let i = 0;
 	const consume = () => tokens[i++];
@@ -269,6 +275,7 @@ export function deconstruct(path: string): DeconstructedPath {
 
 	return Object.freeze({
 		expectedSegments: Object.freeze(expectedSegments),
+		leadingSlash,
 		parameters: Object.freeze(parameters),
 		searchParameters: Object.freeze(searchParameters),
 		trailingSlash

--- a/tests/unit/createRoute.ts
+++ b/tests/unit/createRoute.ts
@@ -544,6 +544,23 @@ suite('createRoute', () => {
 		assert.lengthOf(selections, 2);
 	});
 
+	test('routes can only be appended once', () => {
+		const foo = createRoute({ path: '/foo' });
+		const bar = createRoute({ path: '/bar' });
+		const baz = createRoute({ path: '/baz' });
+
+		foo.append(bar);
+		assert.throws(() => {
+			foo.append(bar);
+		}, Error, 'Cannot append route that has already been appended');
+		assert.throws(() => {
+			foo.append([ bar, baz ]);
+		}, Error, 'Cannot append route that has already been appended');
+		assert.throws(() => {
+			baz.append(bar);
+		}, Error, 'Cannot append route that has already been appended');
+	});
+
 	// This test is mostly there to verify the typings at compile time.
 	test('createRoute() takes a Context type', () => {
 		interface Refined extends Context {

--- a/tests/unit/createRoute.ts
+++ b/tests/unit/createRoute.ts
@@ -198,7 +198,7 @@ suite('createRoute', () => {
 		const { path } = createRoute({ path: '/foo/{bar}?{baz}' });
 		assert.isTrue(Object.isFrozen(path));
 
-		const { expectedSegments, parameters, searchParameters, trailingSlash } = path;
+		const { expectedSegments, leadingSlash, parameters, searchParameters, trailingSlash } = path;
 		assert.isTrue(Object.isFrozen(expectedSegments));
 		assert.isTrue(Object.isFrozen(parameters));
 		assert.isTrue(Object.isFrozen(searchParameters));
@@ -211,6 +211,7 @@ suite('createRoute', () => {
 			{ name: 'bar' }
 		]);
 
+		assert.isTrue(leadingSlash);
 		assert.deepEqual(parameters, [ 'bar' ]);
 		assert.deepEqual(searchParameters, [ 'baz' ]);
 		assert.isFalse(trailingSlash);

--- a/tests/unit/createRoute.ts
+++ b/tests/unit/createRoute.ts
@@ -194,6 +194,28 @@ suite('createRoute', () => {
 		}, TypeError, 'Parameter must have a unique name, got \'foo\'');
 	});
 
+	test('deconstructed path can be accessed and is deeply frozen', () => {
+		const { path } = createRoute({ path: '/foo/{bar}?{baz}' });
+		assert.isTrue(Object.isFrozen(path));
+
+		const { expectedSegments, parameters, searchParameters, trailingSlash } = path;
+		assert.isTrue(Object.isFrozen(expectedSegments));
+		assert.isTrue(Object.isFrozen(parameters));
+		assert.isTrue(Object.isFrozen(searchParameters));
+
+		assert.lengthOf(expectedSegments, 2);
+		assert.isTrue(Object.isFrozen(expectedSegments[0]));
+		assert.isTrue(Object.isFrozen(expectedSegments[1]));
+		assert.deepEqual(expectedSegments, [
+			{ literal: 'foo' },
+			{ name: 'bar' }
+		]);
+
+		assert.deepEqual(parameters, [ 'bar' ]);
+		assert.deepEqual(searchParameters, [ 'baz' ]);
+		assert.isFalse(trailingSlash);
+	});
+
 	test('guard() receives the extracted parameters', () => {
 		let received: Parameters = <any> undefined;
 		const route = createRoute<DefaultParameters>({

--- a/tests/unit/createRoute.ts
+++ b/tests/unit/createRoute.ts
@@ -3,6 +3,7 @@ import { suite, test } from 'intern!tdd';
 import * as assert from 'intern/chai!assert';
 
 import createRoute from '../../src/createRoute';
+import { deconstruct as deconstructPath } from '../../src/lib/path';
 import { DefaultParameters, Context, Parameters } from '../../src/interfaces';
 
 suite('createRoute', () => {
@@ -440,6 +441,42 @@ suite('createRoute', () => {
 		assert.lengthOf(selections, 0);
 	});
 
+	test('selections contain expected properties', () => {
+		const root = createRoute({ path: '/foo/{param}?{foo}' });
+		const deep = createRoute({ path: '/bar/{param}?{bar}' });
+		const deeper = createRoute({ path: '/baz/{param}?{foo}&{baz}' });
+		root.append(deep);
+		deep.append(deeper);
+
+		const selections = root.select({} as Context, ['foo', 'root', 'bar', 'deep', 'baz', 'deeper'], false, new UrlSearchParams({
+			'foo': [ 'foo'] ,
+			'baz': [ 'one', 'two' ]
+		}));
+		if (typeof selections === 'string') {
+			throw new TypeError('Unexpected result');
+		}
+
+		assert.lengthOf(selections, 3);
+		const [first, second, third] = selections;
+		assert.deepEqual(first.params, { param: 'root', foo: 'foo' });
+		assert.deepEqual(first.rawPathValues, [ 'root' ]);
+		assert.deepEqual(first.rawSearchParams, { foo: [ 'foo' ] });
+		assert.deepEqual(first.path, deconstructPath('/foo/{param}?{foo}'));
+		assert.strictEqual(first.route, root);
+
+		assert.deepEqual(second.params, { param: 'deep' });
+		assert.deepEqual(second.rawPathValues, [ 'deep' ]);
+		assert.deepEqual(second.rawSearchParams, {});
+		assert.deepEqual(second.path, deconstructPath('/bar/{param}?{bar}'));
+		assert.strictEqual(second.route, deep);
+
+		assert.deepEqual(third.params, { param: 'deeper', foo: 'foo', baz: 'one' });
+		assert.deepEqual(third.rawPathValues, [ 'deeper' ]);
+		assert.deepEqual(third.rawSearchParams, { foo: [ 'foo' ], baz: [ 'one', 'two' ] });
+		assert.deepEqual(third.path, deconstructPath('/baz/{param}?{foo}&{baz}'));
+		assert.strictEqual(third.route, deeper);
+	});
+
 	test('guards can request redirects by returning path strings', () => {
 		const root = createRoute({ path: '/root' });
 		const deep = createRoute({
@@ -464,25 +501,6 @@ suite('createRoute', () => {
 		root.append(deep);
 
 		assert.strictEqual(root.select({} as Context, ['root', 'deep'], false, new UrlSearchParams()), '');
-	});
-
-	test('extracts path parameters for each nested route', () => {
-		const root = createRoute({ path: '/foo/{param}' });
-		const deep = createRoute({ path: '/bar/{param}' });
-		const deeper = createRoute({ path: '/baz/{param}' });
-		root.append(deep);
-		deep.append(deeper);
-
-		const selections = root.select({} as Context, ['foo', 'root', 'bar', 'deep', 'baz', 'deeper'], false, new UrlSearchParams());
-		if (typeof selections === 'string') {
-			throw new TypeError('Unexpected result');
-		}
-
-		assert.lengthOf(selections, 3);
-		const [{ params: first }, { params: second }, { params: third }] = selections;
-		assert.deepEqual(first, { param: 'root' });
-		assert.deepEqual(second, { param: 'deep' });
-		assert.deepEqual(third, { param: 'deeper' });
 	});
 
 	test('guard() is not called unnecessarily', () => {

--- a/tests/unit/createRouter.ts
+++ b/tests/unit/createRouter.ts
@@ -339,6 +339,31 @@ suite('createRouter', () => {
 		});
 	});
 
+	test('routes can only be appended once', () => {
+		const router = createRouter();
+		const foo = createRoute({ path: '/foo' });
+		const bar = createRoute({ path: '/bar' });
+		const baz = createRoute({ path: '/baz' });
+
+		router.append(foo);
+		assert.throws(() => {
+			router.append(foo);
+		}, Error, 'Cannot append route that has already been appended');
+		assert.throws(() => {
+			router.append([ foo, bar ]);
+		}, Error, 'Cannot append route that has already been appended');
+
+		foo.append(bar);
+		assert.throws(() => {
+			router.append(bar);
+		}, Error, 'Cannot append route that has already been appended');
+
+		router.append(baz);
+		assert.throws(() => {
+			router.append(baz);
+		}, Error, 'Cannot append route that has already been appended');
+	});
+
 	test('leading slashes are irrelevant', () => {
 		const router = createRouter();
 		const root = createRoute({ path: '/foo' });

--- a/tests/unit/createRouter.ts
+++ b/tests/unit/createRouter.ts
@@ -4,7 +4,7 @@ import { beforeEach, suite, test } from 'intern!tdd';
 import * as assert from 'intern/chai!assert';
 import { stub, spy } from 'sinon';
 
-import createRoute from '../../src/createRoute';
+import createRoute, { Route } from '../../src/createRoute';
 import createRouter, { DispatchResult, ErrorEvent, NavigationStartEvent } from '../../src/createRouter';
 import createMemoryHistory from '../../src/history/createMemoryHistory';
 import { DefaultParameters, Context, Request, Parameters } from '../../src/interfaces';
@@ -734,6 +734,288 @@ suite('createRouter', () => {
 		history.set('/bar');
 		const { args: [ nextContext ] } = dispatch.secondCall;
 		assert.deepEqual(nextContext, { second: true });
+	});
+
+	test('link() throws if route has not been appended', () => {
+		const router = createRouter();
+		assert.throws(() => {
+			router.link(createRoute({ path: '/' }));
+		}, Error, 'Cannot generate link for route that is not in the hierarchy');
+		assert.throws(() => {
+			const foo = createRoute({ path: '/foo' });
+			const bar = createRoute({ path: '/bar' });
+			foo.append(bar);
+			router.link(bar);
+		}, Error, 'Cannot generate link for route that is not in the hierarchy');
+		assert.throws(() => {
+			const foo = createRoute({ path: '/foo' });
+			createRouter().append(foo);
+			router.link(foo);
+		}, Error, 'Cannot generate link for route that is not in the hierarchy');
+	});
+
+	test('link() combines paths of route hierarchy (no parameters)', () => {
+		const router = createRouter();
+		const routes = ['foo/', '/bar', 'baz/'].map(path => createRoute({ path }));
+		routes.reduce<{ append(route: Route<Context, Parameters>): void }>((parent, route) => {
+				parent.append(route);
+				return route;
+			}, router);
+
+		assert.equal(router.link(routes[2]), 'foo/bar/baz/');
+		assert.equal(router.link(routes[1]), 'foo/bar');
+	});
+
+	test('link() returns a prefixed path if history was provided', () => {
+		const history = createMemoryHistory();
+		history.prefix = (path) => `/prefixed/${path}`;
+		const router = createRouter({ history });
+		const route = createRoute({ path: 'foo' });
+		router.append(route);
+
+		assert.equal(router.link(route), '/prefixed/foo');
+	});
+
+	test('link() throws if parameters are missing', () => {
+		const router = createRouter();
+		const route = createRoute({ path: '/{foo}?{bar}' });
+		router.append(route);
+
+		assert.throws(() => {
+			router.link(route);
+		}, Error, 'Cannot generate link, missing parameter \'foo\'');
+		assert.throws(() => {
+			router.link(route, { foo: 'foo' });
+		}, Error, 'Cannot generate link, missing search parameter \'bar\'');
+	});
+
+	test('link() throws if more than one value is provided for a path parameter', () => {
+		const router = createRouter();
+		const route = createRoute({ path: '/{foo}' });
+		router.append(route);
+
+		assert.equal(router.link(route, { foo: [ 'foo' ] }), '/foo');
+		assert.throws(() => {
+			router.link(route, { foo: [ 'foo', 'bar' ] });
+		}, Error, 'Cannot generate link, multiple values for parameter \'foo\'');
+	});
+
+	test('link() fills in parameters', () => {
+		const router = createRouter();
+		const routes = ['{foo}', '{foo}?{bar}', 'end?{bar}&{baz}&{foo}'].map(path => createRoute({ path }));
+		routes.reduce<{ append(route: Route<Context, Parameters>): void }>((parent, route) => {
+				parent.append(route);
+				return route;
+			}, router);
+
+		assert.equal(router.link(routes[2], {
+			foo: 'foo',
+			bar: 'bar',
+			baz: [ 'baz1', 'baz2' ]
+		}), 'foo/foo/end?bar=bar&baz=baz1&baz=baz2&foo=foo');
+	});
+
+	test('link() fills in parameters from currently selected, matching routes', () => {
+		const history = createMemoryHistory();
+		const router = createRouter({ history });
+		const routes = ['/root/{foo}/deeper/{bar}', '{foo}?{bar}'].map(path => createRoute({ path }));
+		const ready = new Promise((resolve) => {
+			routes.push(createRoute({ path: 'end?{bar}&{baz}&{foo}', exec: resolve }));
+		});
+		routes.reduce<{ append(route: Route<Context, Parameters>): void }>((parent, route) => {
+				parent.append(route);
+				return route;
+			}, router);
+
+		router.start({ dispatchCurrent: false });
+		history.set('/root/FOO/deeper/BAR/foo/end?bar=bar&baz=baz1&baz=baz2&foo=f00');
+
+		return ready.then(() => {
+			assert.equal(router.link(routes[2]), '/root/FOO/deeper/BAR/foo/end?bar=bar&baz=baz1&baz=baz2&foo=f00');
+
+			const route = createRoute({ path: '{bar}' });
+			routes[0].append(route);
+			assert.equal(router.link(route, { bar: 'bar' }), '/root/FOO/deeper/bar/bar');
+		});
+	});
+
+	test('link() lets you override parameters from currently selected, matching routes', () => {
+		const history = createMemoryHistory();
+		const router = createRouter({ history });
+		const routes = ['/root/{foo}/deeper/{bar}', '{foo}?{bar}'].map(path => createRoute({ path }));
+		const ready = new Promise((resolve) => {
+			routes.push(createRoute({ path: 'end?{bar}&{baz}&{foo}', exec: resolve }));
+		});
+		routes.reduce<{ append(route: Route<Context, Parameters>): void }>((parent, route) => {
+				parent.append(route);
+				return route;
+			}, router);
+
+		router.start({ dispatchCurrent: false });
+		history.set('/root/FOO/deeper/BAR/foo/end?bar=bar&baz=baz1&baz=baz2&foo=f00');
+
+		return ready.then(() => {
+			assert.equal(router.link(routes[2], { foo: 'f00' }), '/root/f00/deeper/BAR/f00/end?bar=bar&baz=baz1&baz=baz2&foo=f00');
+		});
+	});
+
+	test('link() is available when executing the currently selected route', () => {
+		const history = createMemoryHistory();
+		const router = createRouter({ history });
+		const initial = createRoute({
+			path: '/initial/{foo}',
+			exec() {
+				history.set('/foo');
+			}
+		});
+		router.append(initial);
+
+		const ready = new Promise((resolve, reject) => {
+			const links: string[] = [];
+			const route = createRoute({
+				path: '/{foo}',
+				guard() {
+					links.push(router.link(initial));
+					return true;
+				},
+				params() {
+					links.push(router.link(initial));
+					return {};
+				},
+				exec() {
+					links.push(router.link(route));
+					resolve(links);
+				}
+			});
+			router.append(route);
+		});
+
+		router.start({ dispatchCurrent: false });
+		history.set('/initial/foo');
+
+		return ready.then((links) => {
+			assert.deepEqual(links, [ '/initial/foo', '/initial/foo', '/foo' ]);
+		});
+	});
+
+	test('there is no currently selected route for link() after a redirect is requested', () => {
+		const history = createMemoryHistory();
+		const router = createRouter({ history });
+		const initial = createRoute({
+			path: '/initial/{foo}',
+			exec() {
+				history.set('/redirect');
+			}
+		});
+		const redirect = createRoute({
+			path: '/redirect',
+			guard() {
+				return '/foo';
+			}
+		});
+		router.append([ initial, redirect ]);
+
+		const ready = new Promise((resolve) => {
+			const route = createRoute({
+				path: '/foo',
+				guard() {
+					resolve(new Promise((resolve) => {
+						resolve(router.link(initial));
+					}));
+					return true;
+				}
+			});
+			router.append(route);
+		});
+
+		router.start({ dispatchCurrent: false });
+		history.set('/initial/foo');
+
+		return ready
+			.then(() => {
+				throw new Error('Should have thrown');
+			})
+			.catch((err) => {
+				assert.equal(err.message, 'Cannot generate link, missing parameter \'foo\'');
+			});
+	});
+
+	test('there is no currently selected route for link() after a dispatch fails', () => {
+		const history = createMemoryHistory();
+		const router = createRouter({ history });
+		const initial = createRoute({
+			path: '/initial/{foo}',
+			exec() {
+				history.set('/missing');
+				setTimeout(() => {
+					history.set('/foo');
+				}, 50);
+			}
+		});
+		router.append(initial);
+
+		const ready = new Promise((resolve) => {
+			const route = createRoute({
+				path: '/foo',
+				guard() {
+					resolve(new Promise((resolve) => {
+						resolve(router.link(initial));
+					}));
+					return true;
+				}
+			});
+			router.append(route);
+		});
+
+		router.start({ dispatchCurrent: false });
+		history.set('/initial/foo');
+
+		return ready
+			.then(() => {
+				throw new Error('Should have thrown');
+			})
+			.catch((err) => {
+				assert.equal(err.message, 'Cannot generate link, missing parameter \'foo\'');
+			});
+	});
+
+	test('there is no currently selected route for link() after an unmanaged dispatch', () => {
+		const history = createMemoryHistory();
+		const router = createRouter({ history });
+		const initial = createRoute({
+			path: '/initial/{foo}',
+			exec() {
+				return router.dispatch({}, '/unmanaged').then(() => {
+					history.set('/foo');
+				});
+			}
+		});
+		const unmanaged = createRoute({ path: '/unmanaged' });
+		router.append([ initial, unmanaged ]);
+
+		const ready = new Promise((resolve) => {
+			const route = createRoute({
+				path: '/foo',
+				guard() {
+					resolve(new Promise((resolve) => {
+						resolve(router.link(initial));
+					}));
+					return true;
+				}
+			});
+			router.append(route);
+		});
+
+		router.start({ dispatchCurrent: false });
+		history.set('/initial/foo');
+
+		return ready
+			.then(() => {
+				throw new Error('Should have thrown');
+			})
+			.catch((err) => {
+				assert.equal(err.message, 'Cannot generate link, missing parameter \'foo\'');
+			});
 	});
 
 	suite('dispatch errors are emitted', () => {

--- a/tests/unit/history/createHashHistory.ts
+++ b/tests/unit/history/createHashHistory.ts
@@ -38,6 +38,10 @@ suite('createHashHistory', () => {
 		assert.equal(createHashHistory().current, window.location.hash.slice(1));
 	});
 
+	test('prefixes the path with a #', () => {
+		assert.equal(createHashHistory().prefix('/foo'), '#/foo');
+	});
+
 	test('update path', () => {
 		const history = createHashHistory({ window: sandbox.contentWindow });
 		history.set('/foo');

--- a/tests/unit/history/createMemoryHistory.ts
+++ b/tests/unit/history/createMemoryHistory.ts
@@ -12,6 +12,10 @@ suite('createMemoryHistory', () => {
 		assert.equal(createMemoryHistory({ path: '/initial'}).current, '/initial');
 	});
 
+	test('does not prefix the path', () => {
+		assert.equal(createMemoryHistory().prefix('/foo'), '/foo');
+	});
+
 	test('update path', () => {
 		const history = createMemoryHistory();
 		history.set('/foo');

--- a/tests/unit/history/createStateHistory.ts
+++ b/tests/unit/history/createStateHistory.ts
@@ -39,6 +39,12 @@ suite('createStateHistory', () => {
 		assert.equal(createStateHistory().current, window.location.pathname + window.location.search);
 	});
 
+	test('prefixes path with leading slash if necessary', () => {
+		const history = createStateHistory({ window: sandbox.contentWindow });
+		assert.equal(history.prefix('/foo'), '/foo');
+		assert.equal(history.prefix('foo'), '/foo');
+	});
+
 	test('update path', () => {
 		const history = createStateHistory({ window: sandbox.contentWindow });
 		history.set('/foo');
@@ -144,6 +150,18 @@ suite('createStateHistory', () => {
 		test('initializes current path to / if it\'s not a base suffix', () => {
 			sandbox.contentWindow.history.pushState({}, '', '/foo/bar?baz');
 			assert.equal(createStateHistory({ base: '/thud/', window: sandbox.contentWindow }).current, '/');
+		});
+
+		test('#prefix prefixes path with the base (with trailing slash)', () => {
+			const history = createStateHistory({ base: '/foo/', window: sandbox.contentWindow });
+			assert.equal(history.prefix('/bar'), '/foo/bar');
+			assert.equal(history.prefix('bar'), '/foo/bar');
+		});
+
+		test('#prefix prefixes path with the base (without trailing slash)', () => {
+			const history = createStateHistory({ base: '/foo', window: sandbox.contentWindow });
+			assert.equal(history.prefix('/bar'), '/foo/bar');
+			assert.equal(history.prefix('bar'), '/foo/bar');
 		});
 
 		test('#set expands the path with the base when pushing state, with trailing slash', () => {


### PR DESCRIPTION
Implements #46. ~~First three commits are from #50, #51 and #52 and can be merged separately.~~

The biggest change from before is that routes can now only be appended once. That is you can't append the same route definition at multiple points in the hierarchy, or in different routers.

Tracking of currently selected routes is only available when using `start()` since `dispatch()` is envisioned to be used concurrently in Node.js servers.

Let me know if you're interested in having `Route#link()` instead of (or in addition to) `Router#link(route)`.
