### PR TITLE
Migrate to @dojo scoped package(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# dojo-routing
+# @dojo/routing
 
 [![Build Status](https://travis-ci.org/dojo/routing.svg?branch=master)](https://travis-ci.org/dojo/routing)
 [![codecov.io](https://codecov.io/github/dojo/routing/coverage.svg?branch=master)](https://codecov.io/github/dojo/routing?branch=master)
-[![npm version](https://badge.fury.io/js/dojo-routing.svg)](https://badge.fury.io/js/dojo-routing)
+[![npm version](https://badge.fury.io/js/@dojo/routing.svg)](https://badge.fury.io/js/@dojo/routing)
 
 A routing library for Dojo 2 applications.
 
@@ -21,7 +21,7 @@ The examples below are provided in TypeScript syntax. The package does work unde
 ### Creating a router
 
 ```ts
-import createRouter from 'dojo-routing/createRouter';
+import createRouter from '@dojo/routing/createRouter';
 
 const router = createRouter();
 ```
@@ -31,7 +31,7 @@ const router = createRouter();
 With the `router` from the previous example:
 
 ```ts
-import createRoute from 'dojo-routing/createRoute';
+import createRoute from '@dojo/routing/createRoute';
 
 router.append(createRoute({ path: '/' }));
 router.append(createRoute({ path: '/about' }));
@@ -55,7 +55,7 @@ Routes can only be appended to a router once.
 The router doesn't track navigation events by itself. Changed paths need to be dispatched by application code. Context must be provided, this is made available to the matched routes.
 
 ```ts
-import { Context } from 'dojo-routing/interfaces';
+import { Context } from '@dojo/routing/interfaces';
 
 interface AppContext extends Context {
 	someKey: string;
@@ -68,7 +68,7 @@ const context: AppContext = {
 router.dispatch(context, '/about');
 ```
 
-Route selection starts in a future turn. An async Task is returned (see [`dojo-core`](https://github.com/dojo/core)) which is resolved with a result object. The object has a `success` property which is `false` if no route was selected, or dispatch was canceled. It's `true` otherwise.
+Route selection starts in a future turn. An async Task is returned (see [`@dojo/core`](https://github.com/dojo/core)) which is resolved with a result object. The object has a `success` property which is `false` if no route was selected, or dispatch was canceled. It's `true` otherwise.
 
 An optional `redirect` property may be present, in case one of the matched routes requested a redirect. The value of the `redirect` property is the new path. It may be an empty string. No routes are executed when a redirect is returned, instead you're expected to change the path and call `dispatch()` again.
 
@@ -79,7 +79,7 @@ You can cancel the task in case a new navigation event occurs.
 The following creates a simple route. The `exec()` function is called when the route is executed.
 
 ```ts
-import createRoute from 'dojo-routing/createRoute';
+import createRoute from '@dojo/routing/createRoute';
 
 const route = createRoute({
 	path: '/',
@@ -117,7 +117,7 @@ You may return a thenable in order to [capture errors](#capturing-errors). Route
 Routes can be appended to other routes:
 
 ```ts
-import createRoute from 'dojo-routing/createRoute';
+import createRoute from '@dojo/routing/createRoute';
 
 const posts = createRoute({
 	path: '/posts',
@@ -178,8 +178,8 @@ You may return a thenable in order to [capture errors](#capturing-errors). Route
 You can extract pathname segments. These will be added to the `params` object of the `request`:
 
 ```ts
-import createRoute from 'dojo-routing/createRoute';
-import { DefaultParameters } from 'dojo-routing/interfaces';
+import createRoute from '@dojo/routing/createRoute';
+import { DefaultParameters } from '@dojo/routing/interfaces';
 
 createRoute({
 	path: '/posts/{id}',
@@ -196,8 +196,8 @@ Parameter names must not be repeated in the route's path. They can't contain `{`
 You can customize the `params` object:
 
 ```ts
-import createRoute, { Route } from 'dojo-routing/createRoute';
-import { Parameters } from 'dojo-routing/interfaces';
+import createRoute, { Route } from '@dojo/routing/createRoute';
+import { Parameters } from '@dojo/routing/interfaces';
 
 interface MyParams extends Parameters {
 	id: number;
@@ -247,8 +247,8 @@ This also prevents any nested routes from being selected.
 Each route's path may include a search component. Name parameters to extract them into the `params` object:
 
 ```ts
-import createRoute from 'dojo-routing/createRoute';
-import { DefaultParameters } from 'dojo-routing/interfaces';
+import createRoute from '@dojo/routing/createRoute';
+import { DefaultParameters } from '@dojo/routing/interfaces';
 
 createRoute({
 	path: '/posts/{id}?{comment}',
@@ -287,8 +287,8 @@ createRoute({
 By default the `params` object will contain the *first* occurrence of each query parameter. However if you specify a `params()` function you'll get access to *all* values:
 
 ```ts
-import createRoute, { Route } from 'dojo-routing/createRoute';
-import { Parameters } from 'dojo-routing/interfaces';
+import createRoute, { Route } from '@dojo/routing/createRoute';
+import { Parameters } from '@dojo/routing/interfaces';
 
 interface MyParams extends Parameters {
 	id: number;
@@ -315,7 +315,7 @@ const route: Route<MyParams> = createRoute({
 });
 ```
 
-`searchParams` is a `UrlSearchParams` instance from [`dojo-core`](https://github.com/dojo/core).
+`searchParams` is a `UrlSearchParams` instance from [`@dojo/core`](https://github.com/dojo/core).
 
 ### Preventing routes from being selected
 
@@ -514,7 +514,7 @@ This library ships with three history managers. They share the same interface bu
 The recommended manager uses `pushState()` and `replaceState()` to [add or modify history entries](https://developer.mozilla.org/en-US/docs/Web/API/History_API#Adding_and_modifying_history_entries). This requires server-side support to work well:
 
 ```ts
-import createStateHistory from 'dojo-routing/history/createStateHistory';
+import createStateHistory from '@dojo/routing/history/createStateHistory';
 
 const history = createStateHistory();
 ```
@@ -562,7 +562,7 @@ You may specify the base with or without a trailing slash.
 The hash-based manager uses the fragment identifier to store navigation state. This makes it a better fit for applications that are served as a static HTML file:
 
 ```ts
-import createHashHistory from 'dojo-routing/history/createHashHistory';
+import createHashHistory from '@dojo/routing/history/createHashHistory';
 
 const history = createHashHistory();
 ```
@@ -576,7 +576,7 @@ Path strings are stored in the fragment identifier. `history.current` returns th
 Finally there is a memory-backed manager. This isn't very useful in browsers but can be helpful when writing tests.:
 
 ```ts
-import createMemoryHistory from 'dojo-routing/history/createMemoryHistory';
+import createMemoryHistory from '@dojo/routing/history/createMemoryHistory';
 
 const history = createMemoryHistory();
 ```

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "@dojo/compose": "2.0.0-beta.21",
-    "@dojo/core": "2.0.0-alpha.19",
+    "@dojo/core": "2.0.0-alpha.20",
     "@dojo/has": "2.0.0-alpha.7",
     "@dojo/shim": "2.0.0-beta.8"
   },
@@ -33,7 +33,7 @@
     "@types/glob": "~5.0.0",
     "@types/grunt": "~0.4.0",
     "@types/sinon": "~1.16.0",
-    "@dojo/loader": "2.0.0-beta.8",
+    "@dojo/loader": "2.0.0-beta.9",
     "@dojo/interfaces": "2.0.0-alpha.11",
     "grunt": "~1.0.1",
     "grunt-dojo2": ">=2.0.0-beta.22",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dojo-routing",
+  "name": "@dojo/routing",
   "version": "2.0.0-pre",
   "description": "A routing library for Dojo 2 applications",
   "private": true,
@@ -23,18 +23,18 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "dojo-compose": "^2.0.0-beta.18",
-    "dojo-core": "^2.0.0-alpha.18",
-    "dojo-has": "^2.0.0-alpha.6",
-    "dojo-shim": "^2.0.0-beta.7"
+    "@dojo/compose": "2.0.0-beta.21",
+    "@dojo/core": "2.0.0-alpha.19",
+    "@dojo/has": "2.0.0-alpha.7",
+    "@dojo/shim": "2.0.0-beta.8"
   },
   "devDependencies": {
     "@types/chai": "~3.4.0",
     "@types/glob": "~5.0.0",
     "@types/grunt": "~0.4.0",
     "@types/sinon": "~1.16.0",
-    "dojo-loader": "^2.0.0-beta.7",
-    "dojo-interfaces": "^2.0.0-alpha.8",
+    "@dojo/loader": "2.0.0-beta.8",
+    "@dojo/interfaces": "2.0.0-alpha.11",
     "grunt": "~1.0.1",
     "grunt-dojo2": ">=2.0.0-beta.22",
     "intern": "^3.4.1",

--- a/src/createRoute.ts
+++ b/src/createRoute.ts
@@ -1,8 +1,8 @@
-import compose, { ComposeFactory } from 'dojo-compose/compose';
-import UrlSearchParams from 'dojo-core/UrlSearchParams';
-import { Hash } from 'dojo-core/interfaces';
-import WeakMap from 'dojo-shim/WeakMap';
-import { Thenable } from 'dojo-shim/interfaces';
+import compose, { ComposeFactory } from '@dojo/compose/compose';
+import UrlSearchParams from '@dojo/core/UrlSearchParams';
+import { Hash } from '@dojo/core/interfaces';
+import WeakMap from '@dojo/shim/WeakMap';
+import { Thenable } from '@dojo/shim/interfaces';
 
 import { DefaultParameters, Context, Parameters, Request } from './interfaces';
 import { findRouter, hasBeenAppended, LinkParams } from './createRouter';

--- a/src/createRouter.ts
+++ b/src/createRouter.ts
@@ -577,6 +577,7 @@ const createRouter: RouterFactory<Context> = compose.mixin(createEvented, {
 						history.replace(redirect);
 						redirecting = false;
 					}
+					return dispatchResult;
 				});
 			};
 

--- a/src/createRouter.ts
+++ b/src/createRouter.ts
@@ -1,20 +1,20 @@
-import compose, { ComposeFactory } from 'dojo-compose/compose';
-import createEvented from 'dojo-compose/bases/createEvented';
+import compose, { ComposeFactory } from '@dojo/compose/compose';
+import createEvented from '@dojo/compose/bases/createEvented';
 import {
 	Evented,
 	EventedOptions,
 	EventedListener
-} from 'dojo-interfaces/bases';
-import { EventTargettedObject, EventErrorObject } from 'dojo-interfaces/core';
-import { Handle, Hash } from 'dojo-core/interfaces';
+} from '@dojo/interfaces/bases';
+import { EventTargettedObject, EventErrorObject } from '@dojo/interfaces/core';
+import { Handle, Hash } from '@dojo/core/interfaces';
 
-import Task from 'dojo-core/async/Task';
-import { pausable, PausableHandle } from 'dojo-core/on';
-import UrlSearchParams from 'dojo-core/UrlSearchParams';
-import { includes } from 'dojo-shim/array';
-import { Thenable } from 'dojo-shim/interfaces';
-import Promise from 'dojo-shim/Promise';
-import WeakMap from 'dojo-shim/WeakMap';
+import Task from '@dojo/core/async/Task';
+import { pausable, PausableHandle } from '@dojo/core/on';
+import UrlSearchParams from '@dojo/core/UrlSearchParams';
+import { includes } from '@dojo/shim/array';
+import { Thenable } from '@dojo/shim/interfaces';
+import Promise from '@dojo/shim/Promise';
+import WeakMap from '@dojo/shim/WeakMap';
 
 import { Route, SearchParams, Selection } from './createRoute';
 import { Context, Parameters, Request } from './interfaces';

--- a/src/history/_alias-ambient-history.ts
+++ b/src/history/_alias-ambient-history.ts
@@ -1,3 +1,3 @@
 // `History` is an ambient type, referring to the History interface in web browsers.
-// Alias it so it can be exported along with dojo-routing's own History interface.
+// Alias it so it can be exported along with @dojo/routing's own History interface.
 export type BrowserHistory = History;

--- a/src/history/createHashHistory.ts
+++ b/src/history/createHashHistory.ts
@@ -1,8 +1,8 @@
-import compose, { ComposeFactory } from 'dojo-compose/compose';
-import createEvented from 'dojo-compose/bases/createEvented';
-import global from 'dojo-core/global';
-import on from 'dojo-core/on';
-import WeakMap from 'dojo-shim/WeakMap';
+import compose, { ComposeFactory } from '@dojo/compose/compose';
+import createEvented from '@dojo/compose/bases/createEvented';
+import global from '@dojo/core/global';
+import on from '@dojo/core/on';
+import WeakMap from '@dojo/shim/WeakMap';
 
 import { History, HistoryOptions } from './interfaces';
 

--- a/src/history/createMemoryHistory.ts
+++ b/src/history/createMemoryHistory.ts
@@ -1,6 +1,6 @@
-import compose, { ComposeFactory } from 'dojo-compose/compose';
-import createEvented from 'dojo-compose/bases/createEvented';
-import WeakMap from 'dojo-shim/WeakMap';
+import compose, { ComposeFactory } from '@dojo/compose/compose';
+import createEvented from '@dojo/compose/bases/createEvented';
+import WeakMap from '@dojo/shim/WeakMap';
 
 import { History, HistoryOptions } from './interfaces';
 

--- a/src/history/createStateHistory.ts
+++ b/src/history/createStateHistory.ts
@@ -1,8 +1,8 @@
-import compose, { ComposeFactory } from 'dojo-compose/compose';
-import createEvented from 'dojo-compose/bases/createEvented';
-import global from 'dojo-core/global';
-import on from 'dojo-core/on';
-import WeakMap from 'dojo-shim/WeakMap';
+import compose, { ComposeFactory } from '@dojo/compose/compose';
+import createEvented from '@dojo/compose/bases/createEvented';
+import global from '@dojo/core/global';
+import on from '@dojo/core/on';
+import WeakMap from '@dojo/shim/WeakMap';
 
 import { BrowserHistory, History, HistoryOptions } from './interfaces';
 

--- a/src/history/interfaces.ts
+++ b/src/history/interfaces.ts
@@ -2,9 +2,9 @@ import {
 	Evented,
 	EventedOptions,
 	EventedListener
-} from 'dojo-interfaces/bases';
-import { EventTargettedObject } from 'dojo-interfaces/core';
-import { Handle } from 'dojo-core/interfaces';
+} from '@dojo/interfaces/bases';
+import { EventTargettedObject } from '@dojo/interfaces/core';
+import { Handle } from '@dojo/core/interfaces';
 
 export { BrowserHistory } from './_alias-ambient-history';
 

--- a/src/lib/path.ts
+++ b/src/lib/path.ts
@@ -1,4 +1,4 @@
-import UrlSearchParams from 'dojo-core/UrlSearchParams';
+import UrlSearchParams from '@dojo/core/UrlSearchParams';
 
 export interface ParsedPath {
 	/**

--- a/tests/intern-saucelabs.ts
+++ b/tests/intern-saucelabs.ts
@@ -6,7 +6,8 @@ export const environments = [
 	{ browserName: 'firefox', platform: 'Windows 10' },
 	{ browserName: 'chrome', platform: 'Windows 10' },
 	{ browserName: 'safari', version: '9', platform: 'OS X 10.11' },
-	{ browserName: 'android', deviceName: 'Google Nexus 7 HD Emulator' },
+	// Android causes issues on travis because saucelabs is slow
+	// { browserName: 'android', deviceName: 'Google Nexus 7 HD Emulator' },
 	{ browserName: 'iphone', version: '9.3' }
 ];
 

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -12,7 +12,7 @@ export const proxyUrl = 'http://localhost:9000/';
 export const capabilities = {
 	'browserstack.debug': false,
 	project: 'Dojo 2',
-	name: 'dojo-routing'
+	name: '@dojo/routing'
 };
 
 // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
@@ -42,8 +42,8 @@ export const initialBaseUrl: string | null = (function () {
 // The desired AMD loader to use when running unit tests (client.html/client.js). Omit to use the default Dojo
 // loader
 export const loaders = {
-	'host-browser': 'node_modules/dojo-loader/loader.js',
-	'host-node': 'dojo-loader'
+	'host-browser': 'node_modules/@dojo/loader/loader.js',
+	'host-node': '@dojo/loader'
 };
 
 // Configuration options for the module loader; any AMD configuration options supported by the specified AMD loader
@@ -54,10 +54,10 @@ export const loaderOptions = {
 		{ name: 'src', location: '_build/src' },
 		{ name: 'tests', location: '_build/tests' },
 		{ name: 'dojo', location: 'node_modules/intern/browser_modules/dojo' },
-		{ name: 'dojo-compose', location: 'node_modules/dojo-compose' },
-		{ name: 'dojo-core', location: 'node_modules/dojo-core' },
-		{ name: 'dojo-has', location: 'node_modules/dojo-has' },
-		{ name: 'dojo-shim', location: 'node_modules/dojo-shim' },
+		{ name: '@dojo/compose', location: 'node_modules/@dojo/compose' },
+		{ name: '@dojo/core', location: 'node_modules/@dojo/core' },
+		{ name: '@dojo/has', location: 'node_modules/@dojo/has' },
+		{ name: '@dojo/shim', location: 'node_modules/@dojo/shim' },
 		{ name: 'sinon', location: 'node_modules/sinon/pkg', main: 'sinon' }
 	]
 };

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -54,10 +54,7 @@ export const loaderOptions = {
 		{ name: 'src', location: '_build/src' },
 		{ name: 'tests', location: '_build/tests' },
 		{ name: 'dojo', location: 'node_modules/intern/browser_modules/dojo' },
-		{ name: '@dojo/compose', location: 'node_modules/@dojo/compose' },
-		{ name: '@dojo/core', location: 'node_modules/@dojo/core' },
-		{ name: '@dojo/has', location: 'node_modules/@dojo/has' },
-		{ name: '@dojo/shim', location: 'node_modules/@dojo/shim' },
+		{ name: '@dojo', location: 'node_modules/@dojo' },
 		{ name: 'sinon', location: 'node_modules/sinon/pkg', main: 'sinon' }
 	]
 };

--- a/tests/unit/createRoute.ts
+++ b/tests/unit/createRoute.ts
@@ -1,4 +1,4 @@
-import UrlSearchParams from 'dojo-core/UrlSearchParams';
+import UrlSearchParams from '@dojo/core/UrlSearchParams';
 import { suite, test } from 'intern!tdd';
 import * as assert from 'intern/chai!assert';
 import { stub } from 'sinon';

--- a/tests/unit/createRouter.ts
+++ b/tests/unit/createRouter.ts
@@ -1,5 +1,5 @@
-import Task from 'dojo-core/async/Task';
-import Promise from 'dojo-shim/Promise';
+import Task from '@dojo/core/async/Task';
+import Promise from '@dojo/shim/Promise';
 import { beforeEach, suite, test } from 'intern!tdd';
 import * as assert from 'intern/chai!assert';
 import { stub, spy } from 'sinon';

--- a/tests/unit/history/createHashHistory.ts
+++ b/tests/unit/history/createHashHistory.ts
@@ -1,8 +1,8 @@
-import compose from 'dojo-compose/compose';
-import { Evented } from 'dojo-interfaces/bases';
-import createEvented from 'dojo-compose/bases/createEvented';
-import { emit } from 'dojo-core/on';
-import Promise from 'dojo-shim/Promise';
+import compose from '@dojo/compose/compose';
+import { Evented } from '@dojo/interfaces/bases';
+import createEvented from '@dojo/compose/bases/createEvented';
+import { emit } from '@dojo/core/on';
+import Promise from '@dojo/shim/Promise';
 import { afterEach, beforeEach, suite, test } from 'intern!tdd';
 import * as assert from 'intern/chai!assert';
 

--- a/tests/unit/history/createStateHistory.ts
+++ b/tests/unit/history/createStateHistory.ts
@@ -1,8 +1,8 @@
-import compose from 'dojo-compose/compose';
-import createEvented from 'dojo-compose/bases/createEvented';
-import { Evented } from 'dojo-interfaces/bases';
-import { emit } from 'dojo-core/on';
-import Promise from 'dojo-shim/Promise';
+import compose from '@dojo/compose/compose';
+import createEvented from '@dojo/compose/bases/createEvented';
+import { Evented } from '@dojo/interfaces/bases';
+import { emit } from '@dojo/core/on';
+import Promise from '@dojo/shim/Promise';
 import { afterEach, beforeEach, suite, test } from 'intern!tdd';
 import * as assert from 'intern/chai!assert';
 

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -12,31 +12,31 @@ registerSuite({
 	name: 'main',
 
 	'#createRoute': {
-		'is the same as dojo-routing/createRoute'() {
+		'is the same as @dojo/routing/createRoute'() {
 			assert.strictEqual(main.createRoute, createRoute);
 		}
 	},
 
 	'#createRouter': {
-		'is the same as dojo-routing/createRouter'() {
+		'is the same as @dojo/routing/createRouter'() {
 			assert.strictEqual(main.createRouter, createRouter);
 		}
 	},
 
 	'#history.createHashHistory': {
-		'is the same as dojo-routing/history/createHashHistory'() {
+		'is the same as @dojo/routing/history/createHashHistory'() {
 			assert.strictEqual(main.history.createHashHistory, createHashHistory);
 		}
 	},
 
 	'#history.createMemoryHistory': {
-		'is the same as dojo-routing/history/createMemoryHistory'() {
+		'is the same as @dojo/routing/history/createMemoryHistory'() {
 			assert.strictEqual(main.history.createMemoryHistory, createMemoryHistory);
 		}
 	},
 
 	'#history.createStateHistory': {
-		'is the same as dojo-routing/history/createStateHistory'() {
+		'is the same as @dojo/routing/history/createStateHistory'() {
 			assert.strictEqual(main.history.createStateHistory, createStateHistory);
 		}
 	}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue

**Description:**

Update `package.json` and all dependency references to use `@dojo` namespace.

Related to https://github.com/dojo/meta/issues/129