### PR TITLE
Wait for a route to resolve before executing child routes when it returns a promise.

### DIFF
--- a/tests/unit/Router.ts
+++ b/tests/unit/Router.ts
@@ -223,6 +223,32 @@ suite('Router', () => {
 		});
 	});
 
+	test('if a dispatch() call errors subsequent segments are not dispatched', () => {
+		const order: string[] = [];
+		const router = new Router();
+		const routeOne = new Route({
+			path: '/foo',
+			exec () {
+				throw 'error';
+			}
+		});
+		const routeTwo = new Route({
+			path: '/bar',
+			exec () {
+				order.push('second');
+			}
+		});
+		routeOne.append(routeTwo);
+		router.append(routeOne);
+
+		return router.dispatch({} as Context, '/foo/bar').then(() => {
+			assert.fail('Should not be called');
+		}).catch((error) => {
+			assert.strictEqual(error, 'error');
+			assert.deepEqual(order, []);
+		});
+	});
+
 	test('dispatch() emits navstart event', () => {
 		const router = new Router();
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Currently a `thenable` return is supported by the `exec` & `fallback` methods of a route but processing of child routes does not wait for this return to resolve.

This changes the behaviour to ensure the parent routes are resolved before processing a child route. It is common that applications build state at each route with actions of child routes requiring state that is created/fetched etc by the parent and therefore necessary when a `thenable` is returned to wait until is has been successfully resolved.


Resolves #83 