### PR TITLE
[POC/WIP] Dojo 2 Routing 

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "peerDependencies": {
     "@dojo/core": "next",
     "@dojo/has": "next",
-    "@dojo/shim": "next"
+    "@dojo/shim": "next",
+    "@dojo/widget-core": "next"
   },
   "devDependencies": {
     "@dojo/interfaces": "next",

--- a/src/Routing.ts
+++ b/src/Routing.ts
@@ -48,8 +48,8 @@ export class RouterContext extends Evented {
 		return this._router;
 	}
 
-	public addOutlet(outlet: string, params: any, currentPath: string, type: 'outlet' | 'fallback' | 'index' = 'outlet') {
-		this._outletStack.set(outlet, { params, type, currentPath });
+	public addOutlet(outlet: string, params: any, location: string, type: 'outlet' | 'fallback' | 'index' = 'outlet') {
+		this._outletStack.set(outlet, { params, type, location });
 	}
 
 	public getOutlet(outlet: string): any {
@@ -144,10 +144,10 @@ export class RouterInjector extends BaseInjector<RouterContext> {
 	@beforeRender()
 	protected beforeRender(renderFunc: any, properties: any, children: any[]) {
 		const { outlet, mainComponent, indexComponent, mapParams } = properties.getProperties(this.toInject(), properties);
-		const { params = {}, type, currentPath } = this.context.getOutlet(outlet);
+		const { params = {}, type, location } = this.context.getOutlet(outlet);
 
 		properties.getProperties = (injected: RouterContext, properties: any) => {
-			return mapParams(params, type, currentPath);
+			return mapParams(params, type, location);
 		};
 
 		if ((type === 'index' || type === 'fallback') && indexComponent) {
@@ -168,7 +168,7 @@ export type Outlet<W extends WidgetBaseInterface, F extends WidgetBaseInterface>
 export function Outlet<W extends WidgetBaseInterface, F extends WidgetBaseInterface>(
 	outletComponents: Component<W> | OutletComponents<W, F>,
 	outlet: string,
-	mapParams: Function = (params: any, type: string, currentPath: string) => { return { ...params, type, currentPath }; }
+	mapParams: Function = (params: any, type: string, location: string) => { return { ...params, type, location }; }
 ): Outlet<W, F> {
 	const indexComponent = isComponent(outletComponents) ? undefined : outletComponents.index;
 	const mainComponent = isComponent(outletComponents) ? outletComponents : outletComponents.component;

--- a/src/Routing.ts
+++ b/src/Routing.ts
@@ -1,0 +1,192 @@
+import Map from '@dojo/shim/Map';
+import { Evented } from '@dojo/core/Evented';
+import { Constructor, RegistryLabel, DNode, WidgetBaseInterface, WidgetProperties } from '@dojo/widget-core/interfaces';
+import { beforeRender, WidgetBase } from '@dojo/widget-core/WidgetBase';
+import { BaseInjector, Injector } from '@dojo/widget-core/Injector';
+import { w, registry } from '@dojo/widget-core/d';
+
+import HashHistory from './history/HashHistory';
+import { History } from './history/interfaces';
+import { Router } from './Router';
+import { Route } from './Route';
+
+/**
+ * Config for registering routes
+ */
+export interface RouteConfig {
+	path: string;
+	outlet: string;
+	children?: RouteConfig[];
+}
+
+/**
+ * Key for the router injetor
+ */
+export const routerKey = Symbol();
+
+/**
+ * Router context used to maintain state for receiving outlets
+ */
+export class RouterContext extends Evented {
+
+	/**
+	 * Outlet stack
+	 */
+	private _outletStack: Map<string, any> = new Map<string, any>();
+
+	/**
+	 * Registered Router
+	 */
+	private _router: Router<any>;
+
+	constructor(router: Router<any>) {
+		super({});
+		this._router = router;
+	}
+
+	get router(): Router<any> {
+		return this._router;
+	}
+
+	public addOutlet(outlet: string, params: any, currentPath: string, type: 'outlet' | 'fallback' | 'index' = 'outlet') {
+		this._outletStack.set(outlet, { params, type, currentPath });
+	}
+
+	public getOutlet(outlet: string): any {
+		return this._outletStack.get(outlet) || {};
+	}
+
+	public reset(): void {
+		this._outletStack.clear();
+	}
+}
+
+/**
+ * Creates a router instance for a specific History manager (default is `HashHistory`) and registers
+ * the route configuration.
+ *
+ * @param routes The routes to register for the router
+ * @param history The history manager the router needs to use, default `HashHistory`
+ */
+export function registerRouter(routes: RouteConfig[], history: History = new HashHistory()): Router<any> {
+	if (registry.has(routerKey)) {
+		throw new Error('Router has already been defined');
+	}
+	const router = new Router({ history, fallback: function(this: Router<any>) {
+		this.emit<any>({ type: 'outlet', outlet: 'errorOutlet' });
+	} });
+	const context = new RouterContext(router);
+	registry.define(routerKey, Injector(RouterInjector, context));
+	registerRoutes(routes, router, context);
+	return router;
+}
+
+/**
+ * @param routes
+ * @param router
+ * @param context
+ */
+export function registerRoutes(routes: RouteConfig[], router: Router<any>, context: RouterContext, parentRoute?: Route<any, any>) {
+	routes.forEach((routeDef) => {
+		const route = new Route({
+			path: routeDef.path,
+			exec(request) {
+				context.addOutlet(routeDef.outlet, request.params, router.link(route));
+			},
+			fallback(request) {
+				context.addOutlet(routeDef.outlet, request.params, router.link(route), 'fallback');
+			},
+			index(request) {
+				context.addOutlet(routeDef.outlet, request.params, router.link(route), 'index');
+			}
+		});
+		if (parentRoute !== undefined) {
+			parentRoute.append(route);
+		}
+		else {
+			router.append(route);
+		}
+		if (routeDef.children) {
+			registerRoutes(routeDef.children, router, context, route);
+		}
+	});
+}
+
+/**
+ * Component type
+ */
+export type Component<W extends WidgetBaseInterface = WidgetBaseInterface> = Constructor<W> | RegistryLabel;
+
+/**
+ * Determine if the property is a Component
+ */
+export function isComponent<W extends WidgetBaseInterface, F extends WidgetBaseInterface>(value: any): value is Component<W> {
+	return Boolean(value && ((typeof value === 'string') || (typeof value === 'function') || (typeof value === 'symbol')));
+}
+
+/**
+ * Outlet component options
+ */
+export interface OutletComponents<W extends WidgetBaseInterface, F extends WidgetBaseInterface> {
+	component?: Component<W>;
+	index?: Component<F>;
+}
+
+export class RouterInjector extends BaseInjector<RouterContext> {
+	constructor(context: RouterContext) {
+		super(context);
+		context.router.on('navstart', (event: any) => {
+			context.reset();
+			this.invalidate();
+		});
+	}
+
+	@beforeRender()
+	protected beforeRender(renderFunc: any, properties: any, children: any[]) {
+		const { outlet, mainComponent, indexComponent, mapParams } = properties.getProperties(this.toInject(), properties);
+		const { params = {}, type, currentPath } = this.context.getOutlet(outlet);
+
+		properties.getProperties = (injected: RouterContext, properties: any) => {
+			return mapParams(params, type, currentPath);
+		};
+
+		if ((type === 'index' || type === 'fallback') && indexComponent) {
+			properties.render = () => w(indexComponent, properties.properties, children);
+		}
+		if (type && mainComponent) {
+			properties.render = () => w(mainComponent, properties.properties, properties.children);
+		}
+		return renderFunc;
+	}
+}
+
+/**
+ * Outlet type
+ */
+export type Outlet<W extends WidgetBaseInterface, F extends WidgetBaseInterface> = Constructor<WidgetBase<Partial<W['properties']> & Partial<F['properties']> & WidgetProperties, null>>;
+
+export function Outlet<W extends WidgetBaseInterface, F extends WidgetBaseInterface>(
+	outletComponents: Component<W> | OutletComponents<W, F>,
+	outlet: string,
+	mapParams: Function = (params: any, type: string, currentPath: string) => { return { ...params, type, currentPath }; }
+): Outlet<W, F> {
+	const indexComponent = isComponent(outletComponents) ? undefined : outletComponents.index;
+	const mainComponent = isComponent(outletComponents) ? outletComponents : outletComponents.component;
+
+	return class extends WidgetBase<any, null> {
+
+		protected render(): DNode {
+			const { children, properties } = this;
+
+			return w<RouterInjector>(routerKey, {
+				scope: this,
+				render: (): DNode => { return null; },
+				getProperties: (injected: Router<any>, properties: any) => {
+					return { outlet, mainComponent, indexComponent, mapParams };
+				},
+				properties,
+				children
+			});
+		}
+	};
+}

--- a/src/examples/ambigious-matches.ts
+++ b/src/examples/ambigious-matches.ts
@@ -37,25 +37,25 @@ const CompanyOutlet = Outlet(Company, 'company');
 const UserOutlet = Outlet(User, 'user', (params: any) => { return { name: params.user }; });
 
 interface AppProperties extends WidgetProperties {
-	currentPath: string;
+	location: string;
 }
 
 class App extends WidgetBase<AppProperties> {
 	render() {
-		const { currentPath } = this.properties;
+		const { location } = this.properties;
 		return v('div', [
 			v('ul', [
 				v('li', [
-					v('a', { href: `${currentPath}/about` }, [ 'About Us (static)' ])
+					v('a', { href: `${location}/about` }, [ 'About Us (static)' ])
 				]),
 				v('li', [
-					v('a', { href: `${currentPath}/company` }, [ 'Company (static)' ])
+					v('a', { href: `${location}/company` }, [ 'Company (static)' ])
 				]),
 				v('li', [
-					v('a', { href: `${currentPath}/kim` }, [ 'Kim (dynamic)' ])
+					v('a', { href: `${location}/kim` }, [ 'Kim (dynamic)' ])
 				]),
 				v('li', [
-					v('a', { href: `${currentPath}/chris` }, [ 'Chris (dyamic)' ])
+					v('a', { href: `${location}/chris` }, [ 'Chris (dyamic)' ])
 				])
 			]),
 			w(AboutOutlet, {}),

--- a/src/examples/ambigious-matches.ts
+++ b/src/examples/ambigious-matches.ts
@@ -1,0 +1,68 @@
+import { WidgetBase } from '@dojo/widget-core/WidgetBase';
+import { v, w } from '@dojo/widget-core/d';
+import { WidgetProperties } from '@dojo/widget-core/interfaces';
+
+import { Outlet } from './../Routing';
+
+interface ChildProperties extends WidgetProperties {
+	name: string;
+}
+
+class About extends WidgetBase {
+	render() {
+		return v('h2', [ 'About' ]);
+	}
+}
+
+class Company extends WidgetBase {
+	render() {
+		return v('h2', [ 'Company' ]);
+	}
+}
+
+interface UserProperties extends WidgetProperties {
+	name: string;
+}
+
+class User extends WidgetBase<UserProperties> {
+	render() {
+		return v('div', [
+			v('h2', [ `User: ${this.properties.name}`])
+		]);
+	}
+}
+
+const AboutOutlet = Outlet(About, 'about');
+const CompanyOutlet = Outlet(Company, 'company');
+const UserOutlet = Outlet(User, 'user', (params: any) => { return { name: params.user }; });
+
+interface AppProperties extends WidgetProperties {
+	currentPath: string;
+}
+
+class App extends WidgetBase<AppProperties> {
+	render() {
+		const { currentPath } = this.properties;
+		return v('div', [
+			v('ul', [
+				v('li', [
+					v('a', { href: `${currentPath}/about` }, [ 'About Us (static)' ])
+				]),
+				v('li', [
+					v('a', { href: `${currentPath}/company` }, [ 'Company (static)' ])
+				]),
+				v('li', [
+					v('a', { href: `${currentPath}/kim` }, [ 'Kim (dynamic)' ])
+				]),
+				v('li', [
+					v('a', { href: `${currentPath}/chris` }, [ 'Chris (dyamic)' ])
+				])
+			]),
+			w(AboutOutlet, {}),
+			w(CompanyOutlet, {}),
+			w(UserOutlet, {})
+		]);
+	}
+}
+
+export const AmbiguousMatchesOutlet = Outlet(App, 'ambiguous-matches');

--- a/src/examples/ambigious-matches.ts
+++ b/src/examples/ambigious-matches.ts
@@ -1,47 +1,47 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { v, w } from '@dojo/widget-core/d';
-import { WidgetProperties } from '@dojo/widget-core/interfaces';
+import { WidgetProperties, DNode } from '@dojo/widget-core/interfaces';
 
-import { Outlet } from './../Routing';
+import { Outlet, RouteConfig } from './../Routing';
 
-interface ChildProperties extends WidgetProperties {
+export interface ChildProperties extends WidgetProperties {
 	name: string;
 }
 
-class About extends WidgetBase {
-	render() {
+export class About extends WidgetBase {
+	render(): DNode {
 		return v('h2', [ 'About' ]);
 	}
 }
 
-class Company extends WidgetBase {
-	render() {
+export class Company extends WidgetBase {
+	render(): DNode {
 		return v('h2', [ 'Company' ]);
 	}
 }
 
-interface UserProperties extends WidgetProperties {
+export interface UserProperties extends WidgetProperties {
 	name: string;
 }
 
-class User extends WidgetBase<UserProperties> {
-	render() {
+export class User extends WidgetBase<UserProperties> {
+	render(): DNode {
 		return v('div', [
 			v('h2', [ `User: ${this.properties.name}`])
 		]);
 	}
 }
 
-const AboutOutlet = Outlet(About, 'about');
-const CompanyOutlet = Outlet(Company, 'company');
-const UserOutlet = Outlet(User, 'user', (params: any) => { return { name: params.user }; });
+export const AboutOutlet = Outlet(About, 'about');
+export const CompanyOutlet = Outlet(Company, 'company');
+export const UserOutlet = Outlet(User, 'user', (params: any) => { return { name: params.user }; });
 
-interface AppProperties extends WidgetProperties {
+export interface AppProperties extends WidgetProperties {
 	location: string;
 }
 
-class App extends WidgetBase<AppProperties> {
-	render() {
+export class App extends WidgetBase<AppProperties> {
+	render(): DNode {
 		const { location } = this.properties;
 		return v('div', [
 			v('ul', [
@@ -64,5 +64,24 @@ class App extends WidgetBase<AppProperties> {
 		]);
 	}
 }
+
+export const AmbiguousMatchesRouteConfig: RouteConfig = {
+	path: 'ambiguous-matches',
+	outlet: 'ambiguous-matches',
+	children: [
+		{
+			path: 'about',
+			outlet: 'about'
+		},
+		{
+			path: 'company',
+			outlet: 'company'
+		},
+		{
+			path: '{user}',
+			outlet: 'user'
+		}
+	]
+};
 
 export const AmbiguousMatchesOutlet = Outlet(App, 'ambiguous-matches');

--- a/src/examples/basic.ts
+++ b/src/examples/basic.ts
@@ -1,0 +1,101 @@
+import { WidgetBase } from '@dojo/widget-core/WidgetBase';
+import { v, w } from '@dojo/widget-core/d';
+import { WidgetProperties } from '@dojo/widget-core/interfaces';
+
+import { Outlet } from './../Routing';
+
+interface ChildProperties extends WidgetProperties {
+	name: string;
+}
+
+class About extends WidgetBase {
+	render() {
+		return v('div', [
+			v('h2', [ 'About' ])
+		]);
+	}
+}
+
+class Home extends WidgetBase {
+	render() {
+		return v('div', [
+			v('h2', [ 'Home' ])
+		]);
+	}
+}
+
+interface TopicsProperties extends WidgetProperties {
+	showHeading: string;
+	currentPath: string;
+}
+
+class Topics extends WidgetBase<TopicsProperties> {
+	render() {
+		const { showHeading, currentPath } = this.properties;
+
+		return v('div', [
+			v('h2', [ 'Topics' ]),
+			v('ul', [
+				v('li', [
+					v('a', { href: `${currentPath}/rendering` }, [ 'Rendering with Dojo 2' ])
+				]),
+				v('li', [
+					v('a', { href: `${currentPath}/widgets` }, [ 'Widgets' ])
+				]),
+				v('li', [
+					v('a', { href: `${currentPath}/props-v-state` },  [ 'Props v State' ])
+				])
+			]),
+			showHeading ? v('h3', [ 'Please select a topic.' ]) : null,
+			w(TopicOutlet, {})
+		]);
+	}
+}
+
+interface TopicProperties extends WidgetProperties {
+	topic: string;
+}
+
+class Topic extends WidgetBase<TopicProperties> {
+	render() {
+		return v('div', [
+			v('h3', [ this.properties.topic ])
+		]);
+	}
+}
+
+const AboutOutlet = Outlet(About, 'about');
+const HomeOutlet = Outlet({ index: Home }, 'home');
+const TopicsOutlet = Outlet(Topics, 'topics', (params: any, type: string, currentPath: string) => {
+	return { showHeading: type === 'index', currentPath };
+});
+const TopicOutlet = Outlet(Topic, 'topic');
+
+interface AppProperties extends WidgetProperties {
+	currentPath: string;
+}
+
+class App extends WidgetBase<AppProperties> {
+	render() {
+		const { currentPath } = this.properties;
+
+		return v('div', [
+			v('ul', [
+				v('li', [
+					v('a', { href: `${currentPath}/home` }, [ 'Home' ])
+				]),
+				v('li', [
+					v('a', { href: `${currentPath}/about` }, [ 'About' ])
+				]),
+				v('li', [
+					v('a', { href: `${currentPath}/topics` }, [ 'Topics' ])
+				])
+			]),
+			w(AboutOutlet, {}),
+			w(HomeOutlet, {}),
+			w(TopicsOutlet, {})
+		]);
+	}
+}
+
+export const BasicAppOutlet = Outlet(App, 'basic');

--- a/src/examples/basic.ts
+++ b/src/examples/basic.ts
@@ -26,24 +26,24 @@ class Home extends WidgetBase {
 
 interface TopicsProperties extends WidgetProperties {
 	showHeading: string;
-	currentPath: string;
+	location: string;
 }
 
 class Topics extends WidgetBase<TopicsProperties> {
 	render() {
-		const { showHeading, currentPath } = this.properties;
+		const { showHeading, location } = this.properties;
 
 		return v('div', [
 			v('h2', [ 'Topics' ]),
 			v('ul', [
 				v('li', [
-					v('a', { href: `${currentPath}/rendering` }, [ 'Rendering with Dojo 2' ])
+					v('a', { href: `${location}/rendering` }, [ 'Rendering with Dojo 2' ])
 				]),
 				v('li', [
-					v('a', { href: `${currentPath}/widgets` }, [ 'Widgets' ])
+					v('a', { href: `${location}/widgets` }, [ 'Widgets' ])
 				]),
 				v('li', [
-					v('a', { href: `${currentPath}/props-v-state` },  [ 'Props v State' ])
+					v('a', { href: `${location}/props-v-state` },  [ 'Props v State' ])
 				])
 			]),
 			showHeading ? v('h3', [ 'Please select a topic.' ]) : null,
@@ -66,29 +66,29 @@ class Topic extends WidgetBase<TopicProperties> {
 
 const AboutOutlet = Outlet(About, 'about');
 const HomeOutlet = Outlet({ index: Home }, 'home');
-const TopicsOutlet = Outlet(Topics, 'topics', (params: any, type: string, currentPath: string) => {
-	return { showHeading: type === 'index', currentPath };
+const TopicsOutlet = Outlet(Topics, 'topics', (params: any, type: string, location: string) => {
+	return { showHeading: type === 'index', location };
 });
 const TopicOutlet = Outlet(Topic, 'topic');
 
 interface AppProperties extends WidgetProperties {
-	currentPath: string;
+	location: string;
 }
 
 class App extends WidgetBase<AppProperties> {
 	render() {
-		const { currentPath } = this.properties;
+		const { location } = this.properties;
 
 		return v('div', [
 			v('ul', [
 				v('li', [
-					v('a', { href: `${currentPath}/home` }, [ 'Home' ])
+					v('a', { href: `${location}/home` }, [ 'Home' ])
 				]),
 				v('li', [
-					v('a', { href: `${currentPath}/about` }, [ 'About' ])
+					v('a', { href: `${location}/about` }, [ 'About' ])
 				]),
 				v('li', [
-					v('a', { href: `${currentPath}/topics` }, [ 'Topics' ])
+					v('a', { href: `${location}/topics` }, [ 'Topics' ])
 				])
 			]),
 			w(AboutOutlet, {}),

--- a/src/examples/basic.ts
+++ b/src/examples/basic.ts
@@ -1,36 +1,36 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { v, w } from '@dojo/widget-core/d';
-import { WidgetProperties } from '@dojo/widget-core/interfaces';
+import { WidgetProperties, DNode } from '@dojo/widget-core/interfaces';
 
-import { Outlet } from './../Routing';
+import { Outlet, RouteConfig } from './../Routing';
 
-interface ChildProperties extends WidgetProperties {
+export interface ChildProperties extends WidgetProperties {
 	name: string;
 }
 
-class About extends WidgetBase {
-	render() {
+export class About extends WidgetBase {
+	render(): DNode {
 		return v('div', [
 			v('h2', [ 'About' ])
 		]);
 	}
 }
 
-class Home extends WidgetBase {
-	render() {
+export class Home extends WidgetBase {
+	render(): DNode {
 		return v('div', [
 			v('h2', [ 'Home' ])
 		]);
 	}
 }
 
-interface TopicsProperties extends WidgetProperties {
+export interface TopicsProperties extends WidgetProperties {
 	showHeading: string;
 	location: string;
 }
 
-class Topics extends WidgetBase<TopicsProperties> {
-	render() {
+export class Topics extends WidgetBase<TopicsProperties> {
+	render(): DNode {
 		const { showHeading, location } = this.properties;
 
 		return v('div', [
@@ -52,31 +52,31 @@ class Topics extends WidgetBase<TopicsProperties> {
 	}
 }
 
-interface TopicProperties extends WidgetProperties {
+export interface TopicProperties extends WidgetProperties {
 	topic: string;
 }
 
-class Topic extends WidgetBase<TopicProperties> {
-	render() {
+export class Topic extends WidgetBase<TopicProperties> {
+	render(): DNode {
 		return v('div', [
 			v('h3', [ this.properties.topic ])
 		]);
 	}
 }
 
-const AboutOutlet = Outlet(About, 'about');
-const HomeOutlet = Outlet({ index: Home }, 'home');
-const TopicsOutlet = Outlet(Topics, 'topics', (params: any, type: string, location: string) => {
+export const AboutOutlet = Outlet(About, 'about');
+export const HomeOutlet = Outlet({ index: Home }, 'home');
+export const TopicsOutlet = Outlet(Topics, 'topics', (params: any, type: string, location: string) => {
 	return { showHeading: type === 'index', location };
 });
-const TopicOutlet = Outlet(Topic, 'topic');
+export const TopicOutlet = Outlet(Topic, 'topic');
 
-interface AppProperties extends WidgetProperties {
+export interface AppProperties extends WidgetProperties {
 	location: string;
 }
 
-class App extends WidgetBase<AppProperties> {
-	render() {
+export class App extends WidgetBase<AppProperties> {
+	render(): DNode {
 		const { location } = this.properties;
 
 		return v('div', [
@@ -97,5 +97,30 @@ class App extends WidgetBase<AppProperties> {
 		]);
 	}
 }
+
+export const BasicAppRouteConfig: RouteConfig = {
+	path: 'basic',
+	outlet: 'basic',
+	children: [
+		{
+			path: 'home',
+			outlet: 'home'
+		},
+		{
+			path: 'about',
+			outlet: 'about'
+		},
+		{
+			path: 'topics',
+			outlet: 'topics',
+			children: [
+				{
+					path: '{topic}',
+					outlet: 'topic'
+				}
+			]
+		}
+	]
+};
 
 export const BasicAppOutlet = Outlet(App, 'basic');

--- a/src/examples/index.html
+++ b/src/examples/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Example</title>
+	<link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body>
+	<script src="../../../node_modules/@dojo/loader/loader.min.js"></script>
+	<script src="../../../node_modules/maquette/dist/css-transitions.min.js"></script>
+	<script>
+		require.config({
+			baseUrl: '.',
+			packages: [
+				{ name: 'src', location: '../../_build' },
+				{ name: '@dojo', location: '../../../node_modules/@dojo' },
+				{ name: 'pepjs', location: '../../../node_modules/pepjs/dist', main: 'pep' },
+				{ name: 'maquette', location: '../../../node_modules/maquette/dist', main: 'maquette' }
+			]
+		});
+
+		require([ './main' ], function () {});
+	</script>
+</body>
+</html>
+

--- a/src/examples/main.ts
+++ b/src/examples/main.ts
@@ -1,0 +1,129 @@
+import { WidgetBase } from '@dojo/widget-core/WidgetBase';
+import { v, w } from '@dojo/widget-core/d';
+import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
+
+import { registerRouter, RouteConfig } from './../Routing';
+import { BasicAppOutlet } from './basic';
+import { UrlParametersAppOutlet } from './url-parameters';
+import { AmbiguousMatchesOutlet } from './ambigious-matches';
+
+const applicationRoutes: RouteConfig[] = [
+	{
+		path: 'basic',
+		outlet: 'basic',
+		children: [
+			{
+				path: 'home',
+				outlet: 'home'
+			},
+			{
+				path: 'about',
+				outlet: 'about'
+			},
+			{
+				path: 'topics',
+				outlet: 'topics',
+				children: [
+					{
+						path: '{topic}',
+						outlet: 'topic'
+					}
+				]
+			}
+		]
+	},
+	{
+		path: 'url-parameters',
+		outlet: 'url-parameters',
+		children: [
+			{
+				path: '{id}',
+				outlet: 'child'
+			}
+		]
+	},
+	{
+		path: 'ambiguous-matches',
+		outlet: 'ambiguous-matches',
+		children: [
+			{
+				path: 'about',
+				outlet: 'about'
+			},
+			{
+				path: 'company',
+				outlet: 'company'
+			},
+			{
+				path: '{user}',
+				outlet: 'user'
+			}
+		]
+	}
+];
+
+const router = registerRouter(applicationRoutes);
+
+const linkStyles = { 'text-decoration': 'none', position: 'relative', display: 'block', 'line-height': '1.8', cursor: 'auto', color: 'inherit' };
+
+class App extends WidgetBase {
+	render() {
+		return v('div', [
+			v('div', {
+				styles: {
+					'font-size': '13px',
+					background: '#eee',
+					overflow: 'auto',
+					position: 'fixed',
+					height: '100vh',
+					left: '0px',
+					top: '0px',
+					bottom: '0px',
+					width: '250px',
+					display: 'block'
+				}
+			}, [
+				v('div', {
+					styles: {
+						'line-height': '1.8',
+						padding: '10px',
+						display: 'block'
+					}
+				}, [
+					v('div', {
+						styles: {
+							'text-transform': 'uppercase',
+							'font-weight': 'bold',
+							color: 'hsl(0, 0%, 32%)',
+							'margin-top': '20px',
+							display: 'block'
+						}
+					},  [ 'Examples' ]),
+					v('div', {
+						styles: {
+							'padding-left': '10px',
+							display: 'block'
+						}
+					}, [
+						v('a', { href: '#basic', styles: linkStyles }, [ 'Basic' ]),
+						v('a', { href: '#url-parameters', styles: linkStyles }, [ 'Url Parameters' ]),
+						v('a', { href: '#ambiguous-matches', styles: linkStyles }, [ 'Ambiguous Matches' ])
+					])
+				])
+			]),
+			v('div', { styles: {
+				'margin-left': '250px',
+				display: 'block'
+			} }, [
+				w(BasicAppOutlet, {}),
+				w(UrlParametersAppOutlet, {}),
+				w(AmbiguousMatchesOutlet, {})
+			])
+		]);
+	}
+}
+
+const Projector = ProjectorMixin(App);
+const projector = new Projector();
+projector.append();
+router.start();

--- a/src/examples/main.ts
+++ b/src/examples/main.ts
@@ -3,63 +3,14 @@ import { v, w } from '@dojo/widget-core/d';
 import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 
 import { registerRouter, RouteConfig } from './../Routing';
-import { BasicAppOutlet } from './basic';
-import { UrlParametersAppOutlet } from './url-parameters';
-import { AmbiguousMatchesOutlet } from './ambigious-matches';
+import { BasicAppOutlet, BasicAppRouteConfig } from './basic';
+import { UrlParametersAppOutlet, UrlParametersRouteConfig } from './url-parameters';
+import { AmbiguousMatchesOutlet, AmbiguousMatchesRouteConfig } from './ambigious-matches';
 
 const applicationRoutes: RouteConfig[] = [
-	{
-		path: 'basic',
-		outlet: 'basic',
-		children: [
-			{
-				path: 'home',
-				outlet: 'home'
-			},
-			{
-				path: 'about',
-				outlet: 'about'
-			},
-			{
-				path: 'topics',
-				outlet: 'topics',
-				children: [
-					{
-						path: '{topic}',
-						outlet: 'topic'
-					}
-				]
-			}
-		]
-	},
-	{
-		path: 'url-parameters',
-		outlet: 'url-parameters',
-		children: [
-			{
-				path: '{id}',
-				outlet: 'child'
-			}
-		]
-	},
-	{
-		path: 'ambiguous-matches',
-		outlet: 'ambiguous-matches',
-		children: [
-			{
-				path: 'about',
-				outlet: 'about'
-			},
-			{
-				path: 'company',
-				outlet: 'company'
-			},
-			{
-				path: '{user}',
-				outlet: 'user'
-			}
-		]
-	}
+	BasicAppRouteConfig,
+	UrlParametersRouteConfig,
+	AmbiguousMatchesRouteConfig
 ];
 
 const router = registerRouter(applicationRoutes);

--- a/src/examples/url-parameters.ts
+++ b/src/examples/url-parameters.ts
@@ -20,27 +20,27 @@ class Child extends WidgetBase<ChildProperties> {
 const ChildOutlet = Outlet(Child, 'child', (params: any) => { return { name: params.id }; });
 
 interface AppProperties extends WidgetProperties {
-	currentPath: string;
+	location: string;
 }
 
 class App extends WidgetBase<AppProperties> {
 	render() {
-		const { currentPath } = this.properties;
+		const { location } = this.properties;
 
 		return v('div', [
 			v('h2', [ 'Accounts' ]),
 			v('ul', [
 				v('li', [
-					v('a', { href: `${currentPath}/netflix` }, [ 'Netflix' ])
+					v('a', { href: `${location}/netflix` }, [ 'Netflix' ])
 				]),
 				v('li', [
-					v('a', { href: `${currentPath}/zillow-group` }, [ 'Zillow Group' ])
+					v('a', { href: `${location}/zillow-group` }, [ 'Zillow Group' ])
 				]),
 				v('li', [
-					v('a', { href: `${currentPath}/yahoo` }, [ 'Yahoo' ])
+					v('a', { href: `${location}/yahoo` }, [ 'Yahoo' ])
 				]),
 				v('li', [
-					v('a', { href: `${currentPath}/modus-create` }, [ 'Modus Create' ])
+					v('a', { href: `${location}/modus-create` }, [ 'Modus Create' ])
 				])
 			]),
 			w(ChildOutlet, {})

--- a/src/examples/url-parameters.ts
+++ b/src/examples/url-parameters.ts
@@ -1,0 +1,51 @@
+import { WidgetBase } from '@dojo/widget-core/WidgetBase';
+import { v, w } from '@dojo/widget-core/d';
+import { WidgetProperties } from '@dojo/widget-core/interfaces';
+
+import { Outlet } from './../Routing';
+
+interface ChildProperties extends WidgetProperties {
+	name: string;
+}
+
+class Child extends WidgetBase<ChildProperties> {
+	render() {
+		console.log('Child Render');
+		return v('div', [
+			v('h3', [ `ID: ${this.properties.name || 'this must be about'}` ])
+		]);
+	}
+}
+
+const ChildOutlet = Outlet(Child, 'child', (params: any) => { return { name: params.id }; });
+
+interface AppProperties extends WidgetProperties {
+	currentPath: string;
+}
+
+class App extends WidgetBase<AppProperties> {
+	render() {
+		const { currentPath } = this.properties;
+
+		return v('div', [
+			v('h2', [ 'Accounts' ]),
+			v('ul', [
+				v('li', [
+					v('a', { href: `${currentPath}/netflix` }, [ 'Netflix' ])
+				]),
+				v('li', [
+					v('a', { href: `${currentPath}/zillow-group` }, [ 'Zillow Group' ])
+				]),
+				v('li', [
+					v('a', { href: `${currentPath}/yahoo` }, [ 'Yahoo' ])
+				]),
+				v('li', [
+					v('a', { href: `${currentPath}/modus-create` }, [ 'Modus Create' ])
+				])
+			]),
+			w(ChildOutlet, {})
+		]);
+	}
+}
+
+export const UrlParametersAppOutlet = Outlet(App, 'url-parameters');

--- a/src/examples/url-parameters.ts
+++ b/src/examples/url-parameters.ts
@@ -1,15 +1,15 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { v, w } from '@dojo/widget-core/d';
-import { WidgetProperties } from '@dojo/widget-core/interfaces';
+import { WidgetProperties, DNode } from '@dojo/widget-core/interfaces';
 
-import { Outlet } from './../Routing';
+import { Outlet, RouteConfig } from './../Routing';
 
-interface ChildProperties extends WidgetProperties {
+export interface ChildProperties extends WidgetProperties {
 	name: string;
 }
 
-class Child extends WidgetBase<ChildProperties> {
-	render() {
+export class Child extends WidgetBase<ChildProperties> {
+	render(): DNode {
 		console.log('Child Render');
 		return v('div', [
 			v('h3', [ `ID: ${this.properties.name || 'this must be about'}` ])
@@ -17,14 +17,14 @@ class Child extends WidgetBase<ChildProperties> {
 	}
 }
 
-const ChildOutlet = Outlet(Child, 'child', (params: any) => { return { name: params.id }; });
+export const ChildOutlet = Outlet(Child, 'child', (params: any) => { return { name: params.id }; });
 
-interface AppProperties extends WidgetProperties {
+export interface AppProperties extends WidgetProperties {
 	location: string;
 }
 
-class App extends WidgetBase<AppProperties> {
-	render() {
+export class App extends WidgetBase<AppProperties> {
+	render(): DNode {
 		const { location } = this.properties;
 
 		return v('div', [
@@ -47,5 +47,16 @@ class App extends WidgetBase<AppProperties> {
 		]);
 	}
 }
+
+export const UrlParametersRouteConfig: RouteConfig = {
+	path: 'url-parameters',
+	outlet: 'url-parameters',
+	children: [
+		{
+			path: '{id}',
+			outlet: 'child'
+		}
+	]
+};
 
 export const UrlParametersAppOutlet = Outlet(App, 'url-parameters');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
 	"compilerOptions": {
 		"declaration": false,
+		"emitDecoratorMetadata": true,
+		"experimentalDecorators": true,
 		"lib": [
 			"dom",
 			"es5",

--- a/tslint.json
+++ b/tslint.json
@@ -59,7 +59,7 @@
 			"variable-declaration": "onespace"
 		} ],
 		"use-strict": false,
-		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords" ],
+		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords", "allow-pascal-case" ],
 		"whitespace": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
 	}
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Initial POC for Dojo 2 routing, leveraging the the higher order "container" component pattern to inject a router context into registered outlets (components that map to a route) in the widget tree.

Examples are included, in `src/example` and they are running at https://dojo-2-routing-poc.now.sh.

**todo:**

 * Incorporate the routing configuration registration into the router, i.e. `new Router(config);` 
 * Manage attributes such as `outletStack` directly within the router.
 * Add `Link` component
 * Think about how to deal with redirects

Outstanding question, does the router still have value outside of this Dojo 2 widget support?

Related to #88
