### PR TITLE
Handle click in the link and manage setting the router path

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,9 +1,23 @@
 module.exports = function (grunt) {
+	const staticExampleFiles = [ 'src/examples/index.html' ];
+
 	require('grunt-dojo2').initConfig(grunt, {
+		copy: {
+			staticExampleFiles: {
+				expand: true,
+				cwd: 'src',
+				src: staticExampleFiles,
+				dest: '<%= devDirectory %>'
+			}
+		},
 		typedoc: {
 			options: {
 				ignoreCompilerErrors: true // Remove this once compile errors are resolved
 			}
 		}
 	});
+
+	grunt.registerTask('dev', grunt.config.get('devTasks').concat([
+		'copy:staticExampleFiles'
+	]));
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function (grunt) {
 		copy: {
 			staticExampleFiles: {
 				expand: true,
-				cwd: 'src',
+				cwd: '.',
 				src: staticExampleFiles,
 				dest: '<%= devDirectory %>'
 			}

--- a/src/Link.ts
+++ b/src/Link.ts
@@ -42,11 +42,8 @@ export class Link extends WidgetBase<LinkProperties> {
 						}
 					};
 
-					if (!isOutlet) {
-						return { ...properties, onClick: handleOnClick };
-					}
 					return {
-						to: router.link(to, { ...router.getCurrentParams(), ...params }),
+						to: isOutlet ? router.link(to, { ...router.getCurrentParams(), ...params }) : to,
 						onClick: handleOnClick,
 						...props
 					};

--- a/src/Link.ts
+++ b/src/Link.ts
@@ -10,25 +10,44 @@ export interface LinkProperties extends WidgetProperties, VirtualDomProperties {
 	isOutlet?: boolean;
 	params?: any;
 	routerKey?: string;
+	onClick?: (event: MouseEvent) => void;
 	to: string;
 }
 
 export class Link extends WidgetBase<LinkProperties> {
 
+	private _onClick(event: MouseEvent): void {
+		this.properties.onClick && this.properties.onClick(event);
+	}
+
 	@beforeRender()
 	protected withRouter(renderFunc: () => DNode, properties: any, children: any): () => DNode {
-		const { to, isOutlet = true, params = {}, routerKey = globalRouterKey, ...props } = properties;
+		const { to, isOutlet = true, params = {}, routerKey = globalRouterKey, onClick, ...props } = properties;
 		if (this.registries.get(routerKey)) {
 			return () => w<RouterInjector>(routerKey, {
 				scope: this,
 				render: renderFunc,
 				properties,
 				getProperties: (router: Router<any>, properties: LinkProperties) => {
+					const handleOnClick = (event: MouseEvent) => {
+						const { to } = this.properties;
+
+						if (onClick) {
+							onClick(event);
+						}
+
+						if (!event.defaultPrevented && event.button === 0 && !this.properties.target) {
+							event.preventDefault();
+							router.setPath(to);
+						}
+					};
+
 					if (!isOutlet) {
-						return properties;
+						return { ...properties, onClick: handleOnClick };
 					}
 					return {
 						to: router.link(to, { ...router.getCurrentParams(), ...params }),
+						onClick: handleOnClick,
 						...props
 					};
 				},
@@ -40,7 +59,7 @@ export class Link extends WidgetBase<LinkProperties> {
 
 	protected render(): DNode {
 		const { to } = this.properties;
-		const props = { ...this.properties, to: undefined, isOutlet: undefined, params: undefined, routerKey: undefined };
+		const props = { ...this.properties, onclick: this._onClick, onClick: undefined, to: undefined, isOutlet: undefined, params: undefined, routerKey: undefined, router: undefined };
 		return v('a', { ...props, href: to }, this.children);
 	}
 }

--- a/src/history/HashHistory.ts
+++ b/src/history/HashHistory.ts
@@ -32,7 +32,7 @@ export class HashHistory extends HistoryBase implements History {
 		this._browserLocation = browserLocation;
 
 		this.own(on(window, 'hashchange', () => {
-			const path = browserLocation.hash.slice(1);
+			const path = this._normalizePath(browserLocation.hash);
 
 			// Ignore hashchange for the current path. Guards against browsers firing hashchange when the history
 			// manager sets the hash.
@@ -46,14 +46,22 @@ export class HashHistory extends HistoryBase implements History {
 		}));
 	}
 
-	prefix(path: string) {
+	public prefix(path: string) {
 		if (path[0] !== '#') {
 			return `#${path}`;
 		}
 		return path;
 	}
 
+	private _normalizePath(path: string): string {
+		if (path[0] === '#') {
+			path = path.slice(1);
+		}
+		return path;
+	}
+
 	set(path: string) {
+		path = this._normalizePath(path);
 		if (this._current === path) {
 			return;
 		}
@@ -67,6 +75,7 @@ export class HashHistory extends HistoryBase implements History {
 	}
 
 	replace(path: string) {
+		path = this._normalizePath(path);
 		if (this._current === path) {
 			return;
 		}

--- a/tests/unit/Link.ts
+++ b/tests/unit/Link.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import { spy, SinonSpy } from 'sinon';
 
 import { WidgetRegistry } from '@dojo/widget-core/WidgetRegistry';
 import { RegistryMixin } from '@dojo/widget-core/mixins/Registry';
@@ -10,10 +11,27 @@ import MemoryHistory from './../../src/history/MemoryHistory';
 const registry = new WidgetRegistry();
 class RegistryLink extends RegistryMixin(Link) {}
 
-registerRouterInjector([{ path: 'foo', outlet: 'foo' }, { path: 'foo/{foo}', outlet: 'foo2' }], registry, new MemoryHistory());
+const router = registerRouterInjector([{ path: 'foo', outlet: 'foo' }, { path: 'foo/{foo}', outlet: 'foo2' }], registry, new MemoryHistory());
+let routerSetPathSpy: SinonSpy;
+
+function createMockEvent(isRightClick: boolean = false) {
+	return {
+		defaultPrevented: false,
+		preventDefault() {
+			this.defaultPrevented = true;
+		},
+		button: isRightClick ? undefined : 0
+	};
+}
 
 registerSuite({
 	name: 'Link',
+	beforeEach() {
+		routerSetPathSpy = spy(router, 'setPath');
+	},
+	afterEach() {
+		routerSetPathSpy.restore();
+	},
 	'Generate link component for basic outlet'() {
 		const link = new RegistryLink();
 		link.__setProperties__({ to: 'foo', registry });
@@ -34,6 +52,55 @@ registerSuite({
 		const vNode: any = link.__render__();
 		assert.strictEqual(vNode.vnodeSelector, 'a');
 		assert.strictEqual(vNode.properties.href, '#foo/static');
+	},
+	'Set router path on click'() {
+		const link = new RegistryLink();
+		link.__setProperties__({ to: '#foo/static', isOutlet: false, registry });
+		const vNode: any = link.__render__();
+		assert.strictEqual(vNode.vnodeSelector, 'a');
+		assert.strictEqual(vNode.properties.href, '#foo/static');
+		vNode.properties.onclick.call(link, createMockEvent());
+		assert.isTrue(routerSetPathSpy.calledWith('#foo/static'));
+	},
+	'Custom onClick handler can prevent default'() {
+		const link = new RegistryLink();
+		link.__setProperties__({
+			to: 'foo',
+			registry,
+			onClick(event: MouseEvent) {
+				event.preventDefault();
+			}
+		});
+		const vNode: any = link.__render__();
+		assert.strictEqual(vNode.vnodeSelector, 'a');
+		assert.strictEqual(vNode.properties.href, 'foo');
+		vNode.properties.onclick.call(link, createMockEvent());
+		assert.isTrue(routerSetPathSpy.notCalled);
+	},
+	'Does not set router path when target attribute is set'() {
+		const link = new RegistryLink();
+		link.__setProperties__({
+			to: 'foo',
+			registry,
+			target: '_blank'
+		});
+		const vNode: any = link.__render__();
+		assert.strictEqual(vNode.vnodeSelector, 'a');
+		assert.strictEqual(vNode.properties.href, 'foo');
+		vNode.properties.onclick.call(link, createMockEvent());
+		assert.isTrue(routerSetPathSpy.notCalled);
+	},
+	'Does not set router path on right click'() {
+		const link = new RegistryLink();
+		link.__setProperties__({
+			to: 'foo',
+			registry
+		});
+		const vNode: any = link.__render__();
+		assert.strictEqual(vNode.vnodeSelector, 'a');
+		assert.strictEqual(vNode.properties.href, 'foo');
+		vNode.properties.onclick.call(link, createMockEvent(true));
+		assert.isTrue(routerSetPathSpy.notCalled);
 	},
 	'throw error if the injected router cannot be found with the router key'() {
 		const link = new Link();

--- a/tests/unit/history/HashHistory.ts
+++ b/tests/unit/history/HashHistory.ts
@@ -85,7 +85,7 @@ suite('HashHistory', () => {
 		history.on('change', ({ value }) => {
 			emittedValues.push(value);
 		});
-		history.set('#foo');
+		history.set('#/foo');
 		assert.lengthOf(emittedValues, 0);
 	});
 

--- a/tests/unit/history/HashHistory.ts
+++ b/tests/unit/history/HashHistory.ts
@@ -78,6 +78,17 @@ suite('HashHistory', () => {
 		assert.lengthOf(emittedValues, 0);
 	});
 
+	test('does not emit change if path is set to the current value even with a hash', () => {
+		sandbox.contentWindow.location.hash = '/foo';
+		const history = new HashHistory({ window: sandbox.contentWindow });
+		let emittedValues: string[] = [];
+		history.on('change', ({ value }) => {
+			emittedValues.push(value);
+		});
+		history.set('#foo');
+		assert.lengthOf(emittedValues, 0);
+	});
+
 	test('replace path', () => {
 		const history = new HashHistory({ window: sandbox.contentWindow });
 		history.replace('/foo');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Handle the route change within the `Link` component left clicks, unless target attribute has been set which will fallback to normal browser behaviour.

Also add support for custom `onClick` handler that can be passed to the `Link` component, receives the full mouse event and can still prevent further actions using the standard `event.preventDefault`

Resolves #93 
