### PR TITLE
Removing circular dependency from router/route

### DIFF
--- a/src/Route.ts
+++ b/src/Route.ts
@@ -1,107 +1,21 @@
-import { Hash } from '@dojo/core/interfaces';
 import UrlSearchParams from '@dojo/core/UrlSearchParams';
 import { Thenable } from '@dojo/shim/interfaces';
 import WeakMap from '@dojo/shim/WeakMap';
-import { DefaultParameters, Context, Parameters, Request } from './interfaces';
-import { deconstruct as deconstructPath, match as matchPath, DeconstructedPath } from './lib/path';
-import { findRouter, hasBeenAppended, LinkParams } from './Router';
-
-/**
- * Hash object where keys are parameter names and keys are arrays of one or more
- * parameter values.
- */
-export type SearchParams = Hash<string[]>;
-
-/**
- * The type of match for a route
- */
-export enum MatchType {
-	INDEX = 0,
-	PARTIAL,
-	ERROR
-}
-
-/**
- * Describes whether a route matched.
- */
-export interface MatchResult<P> {
-	/**
-	 * Whether there are path segments that weren't matched by this route.
-	 */
-	hasRemaining: boolean;
-
-	/**
-	 * Position in the segments array that the remaining unmatched segments start.
-	 */
-	offset: number;
-
-	/**
-	 * Any extracted parameters. Only available if the route matched.
-	 */
-	params: P;
-
-	/**
-	 * Values for named segments in the path, in order of occurrence.
-	 */
-	rawPathValues: string[];
-
-	/**
-	 * Values for known named query parameters that were actually present in the
-	 * path.
-	 */
-	rawSearchParams: SearchParams;
-}
-
-/**
- * A request handler.
- */
-export type Handler = (request: Request<Context, Parameters>) => void | Thenable<any>;
-
-/**
- * Describes the selection of a particular route.
- */
-export interface Selection {
-	/**
-	 * Which handler should be called when the route is executed.
-	 */
-	handler: Handler;
-
-	/**
-	 * The selected path.
-	 */
-	path: DeconstructedPath;
-
-	/**
-	 * The selected outlet
-	 */
-	outlet: string | undefined;
-
-	/**
-	 * The extracted parameters.
-	 */
-	params: Parameters;
-
-	/**
-	 * Values for named segments in the path, in order of occurrence.
-	 */
-	rawPathValues: string[];
-
-	/**
-	 * Values for known named query parameters that were actually present in the
-	 * path.
-	 */
-	rawSearchParams: SearchParams;
-
-	/**
-	 * The selected route.
-	 */
-	route: Route<Context, Parameters>;
-
-	/**
-	 * The selection type
-	 */
-	type: MatchType;
-}
+import {
+	Context,
+	DefaultParameters,
+	Handler,
+	LinkParams,
+	MatchResult,
+	MatchType,
+	Parameters,
+	Request,
+	RouteInterface,
+	SearchParams,
+	Selection
+} from './interfaces';
+import { deconstruct as deconstructPath, DeconstructedPath, match as matchPath } from './lib/path';
+import { findRouter, hasBeenAppended } from './lib/router';
 
 /**
  * The options for the route.
@@ -193,7 +107,7 @@ function computeDefaultParams(parameters: string[], searchParameters: string[], 
 	return params;
 }
 
-export class Route<C extends Context, P extends Parameters> {
+export class Route<C extends Context, P extends Parameters> implements RouteInterface<C, P> {
 	private _path: DeconstructedPath;
 	private _outlet: string | undefined;
 	private _routes: Route<Context, Parameters>[];

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -1,221 +1,35 @@
-import Map from '@dojo/shim/Map';
-import { assign } from '@dojo/core/lang';
 import Task from '@dojo/core/async/Task';
-import Evented, { BaseEventedEvents } from '@dojo/core/Evented';
-import { Hash } from '@dojo/core/interfaces';
+import Evented from '@dojo/core/Evented';
+import { assign } from '@dojo/core/lang';
 import { pausable, PausableHandle } from '@dojo/core/on';
 import UrlSearchParams from '@dojo/core/UrlSearchParams';
-import { EventedOptions, EventedListener } from '@dojo/interfaces/bases';
-import { EventTargettedObject, EventErrorObject, Handle } from '@dojo/interfaces/core';
 import { includes } from '@dojo/shim/array';
 import { Thenable } from '@dojo/shim/interfaces';
+import Map from '@dojo/shim/Map';
 import Promise from '@dojo/shim/Promise';
-import WeakMap from '@dojo/shim/WeakMap';
 import { History, HistoryChangeEvent } from './history/interfaces';
-import { Context, Parameters, Request } from './interfaces';
+import {
+	Context,
+	DispatchResult,
+	ErrorEvent,
+	LinkParams,
+	MatchType,
+	NavigationStartEvent,
+	OutletContext,
+	Parameters,
+	Request,
+	RouteConfig,
+	RouteInterface,
+	RouterEvents,
+	RouterInterface,
+	RouterOptions,
+	SearchParams,
+	Selection,
+	StartOptions
+} from './interfaces';
 import { isNamedSegment, parse as parsePath } from './lib/path';
-
-import { Route, SearchParams, Selection, MatchType } from './Route';
-
-/**
- * An object to resume or cancel router dispatch.
- */
-export interface DispatchDeferral {
-	/**
-	 * Call to prevent a path from being dispatched.
-	 */
-	cancel(): void;
-
-	/**
-	 * Call to resume a path being dispatched.
-	 */
-	resume(): void;
-}
-
-/**
- * Event object that is emitted for the 'navstart' event.
- */
-export interface NavigationStartEvent extends EventTargettedObject<Router<Context>> {
-	/**
-	 * The path that has been navigated to.
-	 */
-	path: string;
-
-	/**
-	 * Call to prevent the path to be dispatched.
-	 */
-	cancel(): void;
-
-	/**
-	 * Call to defer dispatching of the path
-	 * @return an object which allows the caller to resume or cancel dispatch.
-	 */
-	defer(): DispatchDeferral;
-}
-
-/**
- * Event object that is emitted for the 'error' event.
- */
-export interface ErrorEvent<C extends Context> extends EventErrorObject<Router<C>> {
-	/**
-	 * The context that was being dispatched when the error occurred.
-	 */
-	context: C;
-
-	/**
-	 * The path that was being dispatched when the error occurred.
-	 */
-	path: string;
-}
-
-/**
- * Describes the result of a dispatch.
- */
-export interface DispatchResult {
-	/**
-	 * Whether a route requested a redirect to a different path.
-	 */
-	redirect?: string;
-
-	/**
-	 * False if dispatch was canceled (via the navstart event) or if no routes could be selected. True otherwise.
-	 */
-	success: boolean;
-}
-
-export type LinkParams = Hash<string | string[] | undefined>;
-
-export interface RouterEvents<C extends Context> extends BaseEventedEvents {
-	/**
-	 * Event emitted when dispatch is called, but before routes are selected.
-	 */
-	(type: 'navstart', listener: EventedListener<Router<C>, NavigationStartEvent>): Handle;
-
-	/**
-	 * Event emitted when errors occur during dispatch.
-	 *
-	 * Certain errors may reject the task returned when dispatching, but this task is not always accessible and may
-	 * hide errors if it's canceled.
-	 */
-	(type: 'error', listener: EventedListener<Router<C>, ErrorEvent<C>>): Handle;
-}
-
-/**
- * Config for registering routes
- */
-export interface RouteConfig {
-	/**
-	 * The path of the route
-	 */
-	path: string;
-
-	/**
-	 * The optional outlet associated to the path
-	 */
-	outlet?: string;
-
-	/**
-	 * Optional child route configuration
-	 */
-	children?: RouteConfig[];
-
-	/**
-	 * Default params used to generate a link
-	 */
-	defaultParams?: any;
-
-	/**
-	 * To be used as the default route on router start up
-	 * if the current route doesn't match
-	 */
-	defaultRoute?: boolean;
-}
-
-/**
- * The options for the router.
- */
-export interface RouterOptions<C extends Context> extends EventedOptions {
-	/**
-	 * A Context object to be used for all requests, or a function that provides such an object, called for each
-	 * dispatch.
-	 */
-	context?: C | (() => C);
-
-	/**
-	 * A handler called when no routes match the dispatch path.
-	 * @param request An object whose `context` property contains the dispatch context. No extracted parameters
-	 *   are available.
-	 */
-	fallback?: (request: Request<C, Parameters>) => void | Thenable<any>;
-
-	/**
-	 * The history manager. Routes will be dispatched in response to change events emitted by the manager.
-	 */
-	history?: History;
-
-	/**
-	 * Routing configuration to set up on router creation
-	 */
-	config?: RouteConfig[];
-}
-
-/**
- * The options for the router's start() method.
- */
-export interface StartOptions {
-	/**
-	 * Whether to immediately dispatch with the history's current value.
-	 */
-	dispatchCurrent: boolean;
-}
-
-/**
- * The outlet context
- */
-export interface OutletContext {
-	/**
-	 * The type of match for the outlet
-	 */
-	type: MatchType;
-
-	/**
-	 * The location of the route (link)
-	 */
-	location: string;
-
-	/**
-	 * The params for the specific outlet
-	 */
-	params: any;
-}
-
-const parentMap = new WeakMap<Route<Context, Parameters>, Router<Context>>();
-
-/**
- * Whether the route has been appended to another route or router.
- */
-export function hasBeenAppended(route: Route<Context, Parameters>): boolean {
-	return parentMap.has(route) || route.parent !== undefined;
-}
-
-/**
- * Finds the router whose route hierarchy the route has been appended to.
- *
- * Throws if the route was not appended to any router.
- */
-export function findRouter(route: Route<Context, Parameters>): Router<Context> {
-	while (route.parent) {
-		route = route.parent;
-	}
-
-	const router = parentMap.get(route);
-	if (!router) {
-		throw new Error('Cannot generate link for route that is not in the hierarchy');
-	}
-	else {
-		return router;
-	}
-}
+import { hasBeenAppended, parentMap } from './lib/router';
+import { Route } from './Route';
 
 export const errorOutlet = 'errorOutlet';
 
@@ -253,19 +67,19 @@ function catchRejection(router: Router<Context>, context: Context, path: string,
 	}
 }
 
-export class Router<C extends Context> extends Evented {
+export class Router<C extends Context> extends Evented implements RouterInterface<C> {
 	private _contextFactory: () => Context;
 	private _currentSelection: Selection[];
 	private _dispatchFromStart: boolean;
 	private _fallback?: (request: Request<Context, Parameters>) => void | Thenable<any>;
 	private _history?: History;
-	private _routes: Route<Context, Parameters>[];
+	private _routes: RouteInterface<Context, Parameters>[];
 	private _started?: boolean;
 	private _outletContextMap: Map<string, OutletContext> = new Map<string, OutletContext>();
-	private _outletRouteMap: Map<string, Route<any, any>> = new Map<string, Route<any, any>>();
+	private _outletRouteMap: Map<string, RouteInterface<any, any>> = new Map<string, RouteInterface<any, any>>();
 	private _currentParams: any = {};
 	private _defaultParams: any = {};
-	private _defaultRoute: Route<any, any>;
+	private _defaultRoute: RouteInterface<any, any>;
 
 	on: RouterEvents<C>;
 
@@ -306,8 +120,8 @@ export class Router<C extends Context> extends Evented {
 		}
 	}
 
-	register(config: RouteConfig[], from: string | Router<any> | Route<any, any> = this) {
-		let parent: Router<any> | Route<any, any>;
+	register(config: RouteConfig[], from: string | RouterInterface<any> | RouteInterface<any, any> = this) {
+		let parent: RouterInterface<any> | RouteInterface<any, any>;
 		if (typeof from === 'string') {
 			parent = this._outletRouteMap.get(from) || this;
 		}
@@ -338,8 +152,8 @@ export class Router<C extends Context> extends Evented {
 		});
 	}
 
-	append(add: Route<Context, Parameters> | Route<Context, Parameters>[]) {
-		const append = (route: Route<Context, Parameters>) => {
+	append(add: RouteInterface<Context, Parameters> | RouteInterface<Context, Parameters>[]) {
+		const append = (route: RouteInterface<Context, Parameters>) => {
 			if (hasBeenAppended(route)) {
 				throw new Error('Cannot append route that has already been appended');
 			}
@@ -473,8 +287,8 @@ export class Router<C extends Context> extends Evented {
 		}, cancel);
 	}
 
-	link(routeOrOutlet: Route<Context, Parameters> | string, params: LinkParams = {}): string {
-		let route: Route<Context, Parameters>;
+	link(routeOrOutlet: RouteInterface<Context, Parameters> | string, params: LinkParams = {}): string {
+		let route: RouteInterface<Context, Parameters>;
 		if (typeof routeOrOutlet === 'string') {
 			const item = this._outletRouteMap.get(routeOrOutlet);
 			if (item) {

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -1,6 +1,6 @@
 import Task from '@dojo/core/async/Task';
 import Evented from '@dojo/core/Evented';
-import { assign } from '@dojo/core/lang';
+import { assign } from '@dojo/shim/object';
 import { pausable, PausableHandle } from '@dojo/core/on';
 import UrlSearchParams from '@dojo/core/UrlSearchParams';
 import { includes } from '@dojo/shim/array';

--- a/src/RouterInjector.ts
+++ b/src/RouterInjector.ts
@@ -1,17 +1,16 @@
-import { beforeRender } from '@dojo/widget-core/WidgetBase';
-import { w, registry as globalRegistry } from '@dojo/widget-core/d';
-import { WidgetRegistry } from '@dojo/widget-core/WidgetRegistry';
-import { Injector, BaseInjector, InjectorProperties } from '@dojo/widget-core/Injector';
+import { registry as globalRegistry, w } from '@dojo/widget-core/d';
+import { BaseInjector, Injector, InjectorProperties } from '@dojo/widget-core/Injector';
 import { DNode, RegistryLabel } from '@dojo/widget-core/interfaces';
+import { beforeRender } from '@dojo/widget-core/WidgetBase';
+import { WidgetRegistry } from '@dojo/widget-core/WidgetRegistry';
 
 import HashHistory from './history/HashHistory';
 import { History } from './history/interfaces';
-import { Router, RouteConfig } from './Router';
-import { MatchType } from './Route';
-import { MapParamsOptions, OutletProperties } from './interfaces';
+import { MapParamsOptions, MatchType, OutletProperties, RouteConfig } from './interfaces';
+import { Router } from './Router';
 
 /**
- * Key for the router injetor
+ * Key for the router injector
  */
 export const routerKey = Symbol();
 

--- a/src/examples/basic.ts
+++ b/src/examples/basic.ts
@@ -3,9 +3,8 @@ import { v, w } from '@dojo/widget-core/d';
 import { WidgetProperties, DNode } from '@dojo/widget-core/interfaces';
 
 import { Outlet } from './../Outlet';
-import { MatchType } from './../Route';
 import { Link } from './../Link';
-import { MapParamsOptions } from './../interfaces';
+import { MatchType, MapParamsOptions } from './../interfaces';
 
 export interface ChildProperties extends WidgetProperties {
 	name: string;

--- a/src/examples/main.ts
+++ b/src/examples/main.ts
@@ -2,7 +2,7 @@ import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { v, w } from '@dojo/widget-core/d';
 import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 
-import { RouteConfig } from './../Router';
+import { RouteConfig } from './../interfaces';
 import { registerRouterInjector } from './../RouterInjector';
 import { Link } from './../Link';
 import { BasicAppOutlet, BasicAppRouteConfig } from './basic';

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,13 @@
+import Task from '@dojo/core/async/Task';
+import Evented, { BaseEventedEvents } from '@dojo/core/Evented';
+import { PausableHandle } from '@dojo/core/on';
+import UrlSearchParams from '@dojo/core/UrlSearchParams';
+import { EventedListener, EventedOptions } from '@dojo/interfaces/bases';
+import { EventErrorObject, EventTargettedObject, Handle, Hash } from '@dojo/interfaces/core';
+import { Thenable } from '@dojo/interfaces/shim';
 import { Constructor, RegistryLabel, WidgetBaseInterface } from '@dojo/widget-core/interfaces';
-import { Router } from './Router';
-import { MatchType } from './Route';
+import { History } from './history/interfaces';
+import { DeconstructedPath } from './lib/path';
 
 /**
  * Routes created without a `params()` function will receive a `params` object of this type.
@@ -59,7 +66,7 @@ export interface MapParamsOptions {
 	params: any;
 	type: MatchType;
 	location: string;
-	router: Router<any>;
+	router: RouterInterface<any>;
 }
 
 /**
@@ -78,4 +85,309 @@ export interface OutletProperties<W extends WidgetBaseInterface = WidgetBaseInte
 	indexComponent?: Component<I>;
 	errorComponent?: Component<E>;
 	mapParams?: MapParams;
+}
+
+/**
+ * An object to resume or cancel router dispatch.
+ */
+export interface DispatchDeferral {
+	/**
+	 * Call to prevent a path from being dispatched.
+	 */
+	cancel(): void;
+
+	/**
+	 * Call to resume a path being dispatched.
+	 */
+	resume(): void;
+}
+
+/**
+ * Event object that is emitted for the 'navstart' event.
+ */
+export interface NavigationStartEvent extends EventTargettedObject<RouterInterface<Context>> {
+	/**
+	 * The path that has been navigated to.
+	 */
+	path: string;
+
+	/**
+	 * Call to prevent the path to be dispatched.
+	 */
+	cancel(): void;
+
+	/**
+	 * Call to defer dispatching of the path
+	 * @return an object which allows the caller to resume or cancel dispatch.
+	 */
+	defer(): DispatchDeferral;
+}
+
+/**
+ * Event object that is emitted for the 'error' event.
+ */
+export interface ErrorEvent<C extends Context> extends EventErrorObject<RouterInterface<C>> {
+	/**
+	 * The context that was being dispatched when the error occurred.
+	 */
+	context: C;
+
+	/**
+	 * The path that was being dispatched when the error occurred.
+	 */
+	path: string;
+}
+
+export interface RouterEvents<C extends Context> extends BaseEventedEvents {
+	/**
+	 * Event emitted when dispatch is called, but before routes are selected.
+	 */
+	(type: 'navstart', listener: EventedListener<RouterInterface<C>, NavigationStartEvent>): Handle;
+
+	/**
+	 * Event emitted when errors occur during dispatch.
+	 *
+	 * Certain errors may reject the task returned when dispatching, but this task is not always accessible and may
+	 * hide errors if it's canceled.
+	 */
+	(type: 'error', listener: EventedListener<RouterInterface<C>, ErrorEvent<C>>): Handle;
+}
+
+/**
+ * Config for registering routes
+ */
+export interface RouteConfig {
+	/**
+	 * The path of the route
+	 */
+	path: string;
+
+	/**
+	 * The optional outlet associated to the path
+	 */
+	outlet?: string;
+
+	/**
+	 * Optional child route configuration
+	 */
+	children?: RouteConfig[];
+
+	/**
+	 * Default params used to generate a link
+	 */
+	defaultParams?: any;
+
+	/**
+	 * To be used as the default route on router start up
+	 * if the current route doesn't match
+	 */
+	defaultRoute?: boolean;
+}
+
+/**
+ * Describes the result of a dispatch.
+ */
+export interface DispatchResult {
+	/**
+	 * Whether a route requested a redirect to a different path.
+	 */
+	redirect?: string;
+
+	/**
+	 * False if dispatch was canceled (via the navstart event) or if no routes could be selected. True otherwise.
+	 */
+	success: boolean;
+}
+
+export type LinkParams = Hash<string | string[] | undefined>;
+
+/**
+ * The options for the router.
+ */
+export interface RouterOptions<C extends Context> extends EventedOptions {
+	/**
+	 * A Context object to be used for all requests, or a function that provides such an object, called for each
+	 * dispatch.
+	 */
+	context?: C | (() => C);
+
+	/**
+	 * A handler called when no routes match the dispatch path.
+	 * @param request An object whose `context` property contains the dispatch context. No extracted parameters
+	 *   are available.
+	 */
+	fallback?: (request: Request<C, Parameters>) => void | Thenable<any>;
+
+	/**
+	 * The history manager. Routes will be dispatched in response to change events emitted by the manager.
+	 */
+	history?: History;
+
+	/**
+	 * Routing configuration to set up on router creation
+	 */
+	config?: RouteConfig[];
+}
+
+/**
+ * The options for the router's start() method.
+ */
+export interface StartOptions {
+	/**
+	 * Whether to immediately dispatch with the history's current value.
+	 */
+	dispatchCurrent: boolean;
+}
+
+/**
+ * The outlet context
+ */
+export interface OutletContext {
+	/**
+	 * The type of match for the outlet
+	 */
+	type: MatchType;
+
+	/**
+	 * The location of the route (link)
+	 */
+	location: string;
+
+	/**
+	 * The params for the specific outlet
+	 */
+	params: any;
+}
+
+export interface RouterInterface<C extends Context> extends Evented {
+	on: RouterEvents<C>;
+
+	register(config: RouteConfig[], from: string | RouterInterface<any> | RouteInterface<any, any>): void;
+
+	append(add: RouteInterface<Context, Parameters> | RouteInterface<Context, Parameters>[]): void;
+
+	dispatch(context: Context, path: string): Task<DispatchResult>;
+
+	link(routeOrOutlet: RouteInterface<Context, Parameters> | string, params?: LinkParams): string;
+
+	replacePath(path: string): void;
+
+	setPath(path: string): void;
+
+	hasOutlet(outletId: string): boolean;
+
+	getOutlet(outletId: string): OutletContext | undefined;
+
+	getCurrentParams(): Parameters;
+
+	start(startOptions: StartOptions): PausableHandle;
+}
+
+/**
+ * Hash object where keys are parameter names and keys are arrays of one or more
+ * parameter values.
+ */
+export type SearchParams = Hash<string[]>;
+
+/**
+ * Describes whether a route matched.
+ */
+export interface MatchResult<P> {
+	/**
+	 * Whether there are path segments that weren't matched by this route.
+	 */
+	hasRemaining: boolean;
+
+	/**
+	 * Position in the segments array that the remaining unmatched segments start.
+	 */
+	offset: number;
+
+	/**
+	 * Any extracted parameters. Only available if the route matched.
+	 */
+	params: P;
+
+	/**
+	 * Values for named segments in the path, in order of occurrence.
+	 */
+	rawPathValues: string[];
+
+	/**
+	 * Values for known named query parameters that were actually present in the
+	 * path.
+	 */
+	rawSearchParams: SearchParams;
+}
+
+/**
+ * The type of match for a route
+ */
+export enum MatchType {
+	INDEX = 0,
+	PARTIAL,
+	ERROR
+}
+
+/**
+ * A request handler.
+ */
+export type Handler = (request: Request<Context, Parameters>) => void | Thenable<any>;
+
+/**
+ * Describes the selection of a particular route.
+ */
+export interface Selection {
+	/**
+	 * Which handler should be called when the route is executed.
+	 */
+	handler: Handler;
+
+	/**
+	 * The selected path.
+	 */
+	path: DeconstructedPath;
+
+	/**
+	 * The selected outlet
+	 */
+	outlet: string | undefined;
+
+	/**
+	 * The extracted parameters.
+	 */
+	params: Parameters;
+
+	/**
+	 * Values for named segments in the path, in order of occurrence.
+	 */
+	rawPathValues: string[];
+
+	/**
+	 * Values for known named query parameters that were actually present in the
+	 * path.
+	 */
+	rawSearchParams: SearchParams;
+
+	/**
+	 * The selected route.
+	 */
+	route: RouteInterface<Context, Parameters>;
+
+	/**
+	 * The selection type
+	 */
+	type: MatchType;
+}
+
+export interface RouteInterface<C extends Context, P extends Parameters> {
+	readonly parent: RouteInterface<Context, Parameters> | undefined;
+	readonly path: DeconstructedPath;
+	readonly outlet: string | undefined;
+	readonly defaultParams: P;
+
+	append(add: RouteInterface<Context, Parameters> | RouteInterface<Context, Parameters>[]): void;
+	link(params?: LinkParams): string;
+	match(segments: string[], hasTrailingSlash: boolean, searchParams: UrlSearchParams): null | MatchResult<DefaultParameters | P>;
+	select(context: C, segments: string[], hasTrailingSlash: boolean, searchParams: UrlSearchParams): string | Selection[];
 }

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -1,0 +1,30 @@
+import WeakMap from '@dojo/shim/WeakMap';
+import { Context, Parameters, RouteInterface, RouterInterface } from '../interfaces';
+
+export const parentMap = new WeakMap<RouteInterface<Context, Parameters>, RouterInterface<Context>>();
+
+/**
+ * Whether the route has been appended to another route or router.
+ */
+export function hasBeenAppended(route: RouteInterface<Context, Parameters>): boolean {
+	return parentMap.has(route) || route.parent !== undefined;
+}
+
+/**
+ * Finds the router whose route hierarchy the route has been appended to.
+ *
+ * Throws if the route was not appended to any router.
+ */
+export function findRouter(route: RouteInterface<Context, Parameters>): RouterInterface<Context> {
+	while (route.parent) {
+		route = route.parent;
+	}
+
+	const router = parentMap.get(route);
+	if (!router) {
+		throw new Error('Cannot generate link for route that is not in the hierarchy');
+	}
+	else {
+		return router;
+	}
+}

--- a/tests/unit/Route.ts
+++ b/tests/unit/Route.ts
@@ -2,10 +2,10 @@ import UrlSearchParams from '@dojo/core/UrlSearchParams';
 import { suite, test } from 'intern!tdd';
 import * as assert from 'intern/chai!assert';
 import { stub } from 'sinon';
-import { DefaultParameters, Context, Parameters } from '../../src/interfaces';
+import { Context, DefaultParameters, MatchType, Parameters } from '../../src/interfaces';
 import { deconstruct as deconstructPath } from '../../src/lib/path';
 
-import Route, { MatchType } from '../../src/Route';
+import Route from '../../src/Route';
 import Router from '../../src/Router';
 
 suite('Route', () => {

--- a/tests/unit/Router.ts
+++ b/tests/unit/Router.ts
@@ -2,12 +2,21 @@ import Task from '@dojo/core/async/Task';
 import Promise from '@dojo/shim/Promise';
 import { beforeEach, suite, test } from 'intern!tdd';
 import * as assert from 'intern/chai!assert';
-import { stub, spy } from 'sinon';
+import { spy, stub } from 'sinon';
 import MemoryHistory from '../../src/history/MemoryHistory';
-import { DefaultParameters, Context, Request, Parameters } from '../../src/interfaces';
+import {
+	Context,
+	DefaultParameters,
+	DispatchResult,
+	ErrorEvent,
+	MatchType,
+	NavigationStartEvent,
+	Parameters,
+	Request
+} from '../../src/interfaces';
 
-import Route, { MatchType } from '../../src/Route';
-import Router, { DispatchResult, ErrorEvent, NavigationStartEvent } from '../../src/Router';
+import Route from '../../src/Route';
+import Router from '../../src/Router';
 
 suite('Router', () => {
 	test('dispatch() resolves to unsuccessful result if no route was executed', () => {

--- a/tests/unit/RouterInjector.ts
+++ b/tests/unit/RouterInjector.ts
@@ -1,14 +1,14 @@
-import * as registerSuite from 'intern!object';
-import * as assert from 'intern/chai!assert';
 import { Evented } from '@dojo/core/Evented';
+import { registry } from '@dojo/widget-core/d';
+import { Constructor } from '@dojo/widget-core/interfaces';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { WidgetRegistry } from '@dojo/widget-core/WidgetRegistry';
-import { Constructor } from '@dojo/widget-core/interfaces';
-import { registry } from '@dojo/widget-core/d';
-
-import { MatchType } from './../../src/Route';
-import { RouterInjector, registerRouterInjector, routerKey } from './../../src/RouterInjector';
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
 import MemoryHistory from './../../src/history/MemoryHistory';
+
+import { MatchType } from './../../src/interfaces';
+import { registerRouterInjector, RouterInjector, routerKey } from './../../src/RouterInjector';
 
 class TestRouterInjector extends RouterInjector {
 	public invalidateCount = 0;


### PR DESCRIPTION
The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Removing circular dependency from `Router` and `Route`. Because everything was so intertwined, I ended up moving most declarations to `interfaces`, and created a shared `router` library. Now, both `Router` and `Route` import from `interfaces`, and `Router` needs to import from `Route` (because it creates them and needs the _actual_ class), but `Route` no longer has an import on `Router`.

Resolves #92
