### PR TITLE
The initial dispatches on start should be sync

### DIFF
--- a/src/Router.ts
+++ b/src/Router.ts
@@ -524,12 +524,7 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 			}
 			else if (!success && this._defaultRoute) {
 				const normalizedPath = this._history.normalizePath(this.link(this._defaultRoute));
-				const { success, redirect = undefined } = this._dispatch(context, normalizedPath);
-				if (success && redirect) {
-					redirecting = true;
-					this._history!.replace(redirect);
-					redirecting = false;
-				}
+				this._dispatch(context, normalizedPath);
 			}
 		}
 

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -214,9 +214,7 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 
 			for (const { handler, params, outlet, type, route } of result) {
 				if (outlet) {
-					if (params) {
-						assign(this._currentParams, params);
-					}
+					assign(this._currentParams, params);
 					const location = this.link(route, this._currentParams);
 					this._outletContextMap.set(outlet, { type, params, location });
 					if (type === MatchType.ERROR) {

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -520,6 +520,7 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 			if (success && redirect) {
 				redirecting = true;
 				this._history!.replace(redirect);
+				redirecting = false;
 			}
 			else if (!success && this._defaultRoute) {
 				const normalizedPath = this._history.normalizePath(this.link(this._defaultRoute));
@@ -527,6 +528,7 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 				if (success && redirect) {
 					redirecting = true;
 					this._history!.replace(redirect);
+					redirecting = false;
 				}
 			}
 		}

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -172,12 +172,89 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 		}
 	}
 
-	dispatch(context: Context, path: string): Task<DispatchResult> {
-		// Reset, any further calls can't have come from start(). This is necessary since the navstart listeners
-		// may call dispatch() themselves.
-		let dispatchFromStart = this._dispatchFromStart;
+	private _dispatch(context: Context, path: string, canceled: boolean = false, emit: boolean = true) {
+		if (canceled) {
+			return { success: false };
+		}
+
+		this._currentParams = {};
+		this._outletContextMap.clear();
+
+		if (emit) {
+			this.emit<NavigationStartEvent>({
+				context,
+				path,
+				target: this,
+				type: 'navstart'
+			});
+		}
+
+		const { searchParams, segments, trailingSlash } = parsePath(path);
+		const dispatchFromStart = this._dispatchFromStart;
 		this._dispatchFromStart = false;
 
+		let redirect: undefined | string;
+		const dispatched = this._routes.some((route) => {
+			const result = route.select(context, segments, trailingSlash, searchParams);
+
+			if (typeof result === 'string') {
+				redirect = result;
+				return true;
+			}
+			if (result.length === 0) {
+				return false;
+			}
+
+			// Update the selected routes after selecting new routes, but before invoking the handlers.
+			// This means the original value is available to guard() and params() functions, and the
+			// new value when the newly selected routes are executed.
+			//
+			// Reset selected routes if not dispatched from start().
+			this._currentSelection = dispatchFromStart ? result : [];
+
+			for (const { handler, params, outlet, type, route } of result) {
+				if (outlet) {
+					if (params) {
+						assign(this._currentParams, params);
+					}
+					const location = this.link(route, this._currentParams);
+					this._outletContextMap.set(outlet, { type, params, location });
+					if (type === MatchType.ERROR) {
+						this._outletContextMap.set(errorOutlet, { type: MatchType.PARTIAL, params, location });
+					}
+				}
+				catchRejection(this, context, path, handler({ context, params }));
+			}
+
+			return true;
+		});
+
+		// Reset the selected routes if the dispatch was unsuccessful, or if a redirect was requested.
+		if (!dispatched || redirect !== undefined) {
+			this._currentSelection = [];
+		}
+
+		if (!dispatched) {
+			this._outletContextMap.set(errorOutlet, {
+				type: MatchType.PARTIAL,
+				params: {},
+				location: this._history ? this._history.current : ''
+			});
+			if (this._fallback) {
+				catchRejection(this, context, path, this._fallback({ context, params: {} }));
+				return { success: false };
+			}
+		}
+
+		const result: DispatchResult = { success: dispatched };
+		if (redirect !== undefined) {
+			result.redirect = redirect;
+		}
+		return result;
+
+	}
+
+	dispatch(context: Context, path: string): Task<DispatchResult> {
 		let canceled = false;
 		const cancel = () => {
 			canceled = true;
@@ -188,6 +265,7 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 		this._currentParams = {};
 		this._outletContextMap.clear();
 		this.emit<NavigationStartEvent>({
+			context,
 			cancel,
 			defer () {
 				const { cancel, promise, resume } = createDeferral();
@@ -199,84 +277,17 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 			type: 'navstart'
 		});
 
-		// Synchronous cancelation.
+		// Synchronous cancellation.
 		if (canceled) {
 			return Task.resolve({ success: false });
 		}
 
-		const { searchParams, segments, trailingSlash } = parsePath(path);
 		return new Task<DispatchResult>((resolve, reject) => {
 			// *Always* start dispatching in a future turn, even if there were no deferrals.
 			Promise.all(deferrals).then<DispatchResult, DispatchResult>(
 				() => {
-					// The cancel() function used in the NavigationStartEvent is reused as the Task canceler.
-					// Strictly speaking any navstart listener can cancel the dispatch asynchronously, as long as it
-					// manages to do so before this turn.
-					if (canceled) {
-						return { success: false };
-					}
-
-					let redirect: undefined | string;
-					const dispatched = this._routes.some((route) => {
-						const result = route.select(context, segments, trailingSlash, searchParams);
-
-						if (typeof result === 'string') {
-							redirect = result;
-							return true;
-						}
-						if (result.length === 0) {
-							return false;
-						}
-
-						// Update the selected routes after selecting new routes, but before invoking the handlers.
-						// This means the original value is available to guard() and params() functions, and the
-						// new value when the newly selected routes are executed.
-						//
-						// Reset selected routes if not dispatched from start().
-						this._currentSelection = dispatchFromStart ? result : [];
-
-						for (const { handler, params, outlet, type, route } of result) {
-							if (outlet) {
-								if (params) {
-									assign(this._currentParams, params);
-								}
-								const location = this.link(route, this._currentParams);
-								this._outletContextMap.set(outlet, { type, params, location });
-								if (type === MatchType.ERROR) {
-									this._outletContextMap.set(errorOutlet, { type: MatchType.PARTIAL, params, location });
-								}
-							}
-							catchRejection(this, context, path, handler({ context, params }));
-						}
-
-						return true;
-					});
-
-					// Reset the selected routes if the dispatch was unsuccessful, or if a redirect was requested.
-					if (!dispatched || redirect !== undefined) {
-						this._currentSelection = [];
-					}
-
-					if (!dispatched) {
-						this._outletContextMap.set(errorOutlet, {
-							type: MatchType.PARTIAL,
-							params: {},
-							location: this._history ? this._history.current : ''
-						});
-						if (this._fallback) {
-							catchRejection(this, context, path, this._fallback({ context, params: {} }));
-							return { success: false };
-						}
-					}
-
-					const result: DispatchResult = { success: dispatched };
-					if (redirect !== undefined) {
-						result.redirect = redirect;
-					}
-					return result;
+					return this._dispatch(context, path, canceled, false);
 				},
-				// When deferrals are canceled their corresponding promise is rejected. Ensure the task resolves
-				// with `false` instead of being rejected too.
 				() => {
 					return { success: false };
 				}
@@ -504,11 +515,20 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 		this.own(listener);
 
 		if (dispatchCurrent) {
-			dispatch(this._history.current).then((dispatchResult: DispatchResult) => {
-				if (!dispatchResult.success && this._defaultRoute) {
-					this.setPath(this.link(this._defaultRoute));
+			const context = this._contextFactory();
+			const { success, redirect = undefined } = this._dispatch(context, this._history.current);
+			if (success && redirect) {
+				redirecting = true;
+				this._history!.replace(redirect);
+			}
+			else if (!success && this._defaultRoute) {
+				const normalizedPath = this._history.normalizePath(this.link(this._defaultRoute));
+				const { success, redirect = undefined } = this._dispatch(context, normalizedPath);
+				if (success && redirect) {
+					redirecting = true;
+					this._history!.replace(redirect);
 				}
-			});
+			}
 		}
 
 		return listener;

--- a/src/history/HashHistory.ts
+++ b/src/history/HashHistory.ts
@@ -32,7 +32,7 @@ export class HashHistory extends HistoryBase implements History {
 		this._browserLocation = browserLocation;
 
 		this.own(on(window, 'hashchange', () => {
-			const path = this._normalizePath(browserLocation.hash);
+			const path = this.normalizePath(browserLocation.hash);
 
 			// Ignore hashchange for the current path. Guards against browsers firing hashchange when the history
 			// manager sets the hash.
@@ -53,7 +53,7 @@ export class HashHistory extends HistoryBase implements History {
 		return path;
 	}
 
-	private _normalizePath(path: string): string {
+	public normalizePath(path: string): string {
 		if (path[0] === '#') {
 			path = path.slice(1);
 		}
@@ -61,7 +61,7 @@ export class HashHistory extends HistoryBase implements History {
 	}
 
 	set(path: string) {
-		path = this._normalizePath(path);
+		path = this.normalizePath(path);
 		if (this._current === path) {
 			return;
 		}
@@ -75,7 +75,7 @@ export class HashHistory extends HistoryBase implements History {
 	}
 
 	replace(path: string) {
-		path = this._normalizePath(path);
+		path = this.normalizePath(path);
 		if (this._current === path) {
 			return;
 		}

--- a/src/history/HistoryBase.ts
+++ b/src/history/HistoryBase.ts
@@ -9,6 +9,10 @@ export interface HistoryEvents extends BaseEventedEvents {
 
 export class HistoryBase extends Evented {
 	on: HistoryEvents;
+
+	public normalizePath(path: string): string {
+		return path;
+	}
 }
 
 export default HistoryBase;

--- a/src/history/interfaces.ts
+++ b/src/history/interfaces.ts
@@ -40,7 +40,7 @@ export interface History extends Evented {
 	replace(path: string): void;
 
 	/**
-	 *
+	 * Function that will normalize the path for the history manager
 	 */
 	normalizePath(path: string): string;
 

--- a/src/history/interfaces.ts
+++ b/src/history/interfaces.ts
@@ -40,6 +40,11 @@ export interface History extends Evented {
 	replace(path: string): void;
 
 	/**
+	 *
+	 */
+	normalizePath(path: string): string;
+
+	/**
 	 * Event emitted when the current value is changed, after the browser's history has
 	 * been updated.
 	 */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -112,15 +112,20 @@ export interface NavigationStartEvent extends EventTargettedObject<RouterInterfa
 	path: string;
 
 	/**
+	 * The context for the route
+	 */
+	context: Context;
+
+	/**
 	 * Call to prevent the path to be dispatched.
 	 */
-	cancel(): void;
+	cancel?(): void;
 
 	/**
 	 * Call to defer dispatching of the path
 	 * @return an object which allows the caller to resume or cancel dispatch.
 	 */
-	defer(): DispatchDeferral;
+	defer?(): DispatchDeferral;
 }
 
 /**

--- a/tests/unit/Router.ts
+++ b/tests/unit/Router.ts
@@ -7,7 +7,6 @@ import MemoryHistory from '../../src/history/MemoryHistory';
 import {
 	Context,
 	DefaultParameters,
-	DispatchResult,
 	ErrorEvent,
 	MatchType,
 	NavigationStartEvent,
@@ -218,7 +217,9 @@ suite('Router', () => {
 		const router = new Router();
 		router.append(new Route({ path: '/foo' }));
 		router.on('navstart', event => {
-			event.cancel();
+			if (event.cancel) {
+				event.cancel();
+			}
 		});
 
 		return router.dispatch({} as Context, '/foo').then((dispatchResult) => {
@@ -231,8 +232,10 @@ suite('Router', () => {
 		const router = new Router();
 		router.append(new Route({ path: '/foo' }));
 		router.on('navstart', event => {
-			const { cancel } = event.defer();
-			Promise.resolve().then(cancel);
+			if (event.defer) {
+				const { cancel } = event.defer();
+				Promise.resolve().then(cancel);
+			}
 		});
 
 		return router.dispatch({} as Context, '/foo').then((dispatchResult) => {
@@ -245,8 +248,10 @@ suite('Router', () => {
 		const router = new Router();
 		router.append(new Route({ path: '/foo' }));
 		router.on('navstart', event => {
-			const { resume } = event.defer();
-			Promise.resolve().then(resume);
+			if (event.defer) {
+				const { resume } = event.defer();
+				Promise.resolve().then(resume);
+			}
 		});
 
 		return router.dispatch({} as Context, '/foo').then((dispatchResult) => {
@@ -261,12 +266,16 @@ suite('Router', () => {
 
 		const resumers: {(): void}[] = [];
 		router.on('navstart', event => {
-			const { resume } = event.defer();
-			resumers.push(resume);
+			if (event.defer) {
+				const { resume } = event.defer();
+				resumers.push(resume);
+			}
 		});
 		router.on('navstart', event => {
-			const { resume } = event.defer();
-			resumers.push(resume);
+			if (event.defer) {
+				const { resume } = event.defer();
+				resumers.push(resume);
+			}
 		});
 
 		let dispatched: boolean | undefined = false;
@@ -302,7 +311,9 @@ suite('Router', () => {
 		router.on('navstart', event => {
 			const task = new Router().dispatch({} as Context, '/foo');
 			task.cancel();
-			event.defer().resume();
+			if (event.defer) {
+				event.defer().resume();
+			}
 		});
 
 		return new Promise(resolve => setTimeout(resolve, 10)).then(() => {
@@ -773,10 +784,11 @@ suite('Router', () => {
 	test('start() can immediately dispatch for the current history value', () => {
 		const history = new MemoryHistory({ path: '/foo' });
 		const router = new Router({ history });
-		const dispatch = stub(router, 'dispatch').returns(new Task(() => {}));
 
+		router.on('navstart', (event) => {
+			assert.strictEqual(event.path, '/foo');
+		});
 		router.start({ dispatchCurrent: true });
-		assert.isTrue(dispatch.calledWith({}, '/foo'));
 	});
 
 	test('start() falls back to default route if dispatching current route is not successful', () => {
@@ -788,15 +800,14 @@ suite('Router', () => {
 			}
 		];
 		const router = new Router({ history, config });
-		const task = Promise.resolve({ success: false });
-		const dispatch = stub(router, 'dispatch').returns(task);
-		const setPath = stub(router, 'setPath');
+		const dispatchedPaths: string[] = [];
+
+		router.on('navstart', (event) => {
+			dispatchedPaths.push(event.path);
+		});
 
 		router.start({ dispatchCurrent: true });
-		assert.isTrue(dispatch.firstCall.calledWith({}, '/foo'));
-		return task.then(() => {}).then(() => {
-			assert.isTrue(setPath.firstCall.calledWith('bar'));
-		});
+		assert.deepEqual(dispatchedPaths, [ '/foo', 'bar' ]);
 	});
 
 	test('start() can be configured not to immediately dispatch for the current history value', () => {
@@ -811,10 +822,12 @@ suite('Router', () => {
 	test('start() dispatches immediately by default', () => {
 		const history = new MemoryHistory({ path: '/foo' });
 		const router = new Router({ history });
-		const dispatch = stub(router, 'dispatch').returns(new Task(() => {}));
+
+		router.on('navstart', (event) => {
+			assert.strictEqual(event.path, '/foo');
+		});
 
 		router.start();
-		assert.isTrue(dispatch.calledOnce);
 	});
 
 	test('start() throws if already called', () => {
@@ -828,38 +841,6 @@ suite('Router', () => {
 		start();
 
 		assert.throws(start, /start can only be called once/);
-	});
-
-	test('start() ensures the previous dispatch is canceled', () => {
-		const history = new MemoryHistory({ path: '/foo' });
-		const router = new Router({ history });
-		router.on('navstart', ({ defer }) => {
-			// Defer the dispatch, so cancelation has effect.
-			defer();
-		});
-
-		const dispatch = spy(router, 'dispatch');
-		const assertCanceled = (task: Task<DispatchResult>) => {
-			return new Promise((resolve) => {
-				task.finally(resolve);
-			});
-		};
-
-		router.start();
-
-		assert.isTrue(dispatch.calledOnce);
-		// Need to create this promise before changing the history due to <https://github.com/dojo/core/issues/205>.
-		const assertionPromise = assertCanceled(dispatch.firstCall.returnValue);
-		history.set('/bar');
-		return assertionPromise
-			.then(() => {
-				assert.isTrue(dispatch.calledTwice);
-
-				// Need to create this promise before changing the history due to <https://github.com/dojo/core/issues/205>.
-				const assertionPromise = assertCanceled(dispatch.secondCall.returnValue);
-				history.set('/baz');
-				return assertionPromise;
-			});
 	});
 
 	test('start() replaces history if the dispatch requested a redirect', () => {
@@ -954,47 +935,51 @@ suite('Router', () => {
 	test('without a provided context, start() dispatches with an empty object as the context', () => {
 		const history = new MemoryHistory({ path: '/foo' });
 		const router = new Router({ history });
-		const dispatch = stub(router, 'dispatch').returns(new Task(() => {}));
+		const contexts: Context[] = [];
 
+		router.on('navstart', (event) => {
+			contexts.push(event.context);
+		});
 		router.start();
-		const { args: [ initialContext ] } = dispatch.firstCall;
-		assert.deepEqual(initialContext, {});
 
+		assert.deepEqual(contexts[0], {});
 		history.set('/bar');
-		const { args: [ nextContext ] } = dispatch.secondCall;
-		assert.notStrictEqual(nextContext, initialContext);
-		assert.deepEqual(nextContext, {});
+
+		assert.notStrictEqual(contexts[0], contexts[1]);
+		assert.deepEqual(contexts[1], {});
 	});
 
 	test('with a provided context, start() dispatches with that object as the context', () => {
 		const context = {};
 		const history = new MemoryHistory({ path: '/foo' });
 		const router = new Router({ context, history });
-		const dispatch = stub(router, 'dispatch').returns(new Task(() => {}));
+		const contexts: Context[] = [];
 
+		router.on('navstart', (event) => {
+			contexts.push(event.context);
+		});
 		router.start();
-		const { args: [ initialContext ] } = dispatch.firstCall;
-		assert.strictEqual(initialContext, context);
 
+		assert.strictEqual(contexts[0], context);
 		history.set('/bar');
-		const { args: [ nextContext ] } = dispatch.secondCall;
-		assert.strictEqual(nextContext, context);
+		assert.strictEqual(contexts[1], context);
 	});
 
 	test('with a provided context factory, start() dispatches with factory\'s value as the context', () => {
-		const contexts = [ { first: true }, { second: true } ];
-		const context = () => contexts.shift();
+		const expectedContexts = [ { first: true }, { second: true } ];
+		const context = () => expectedContexts.shift();
 		const history = new MemoryHistory({ path: '/foo' });
 		const router = new Router({ context, history });
-		const dispatch = stub(router, 'dispatch').returns(new Task(() => {}));
+		const contexts: Context[] = [];
+
+		router.on('navstart', (event) => {
+			contexts.push(event.context);
+		});
 
 		router.start();
-		const { args: [ initialContext ] } = dispatch.firstCall;
-		assert.deepEqual(initialContext, { first: true });
-
+		assert.deepEqual(contexts[0], { first: true });
 		history.set('/bar');
-		const { args: [ nextContext ] } = dispatch.secondCall;
-		assert.deepEqual(nextContext, { second: true });
+		assert.deepEqual(contexts[1], { second: true });
 	});
 
 	test('link() throws if route has not been appended', () => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Initial route dispatches during `start` should be synchronous - splits the existing `dispatch` method into the sync part and the async wrapper used for all subsequent routes.

Resolves #105