### PR TITLE
Update CI for new release of grunt-dojo2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 - travis_retry npm install
 script:
 - grunt
-- grunt intern:browserstack
+- grunt intern:browserstack --test-reporter
 - grunt uploadCoverage
 - grunt doc
 notifications:

--- a/intern.json
+++ b/intern.json
@@ -22,7 +22,6 @@
 					{ "name": "tests", "location": "_build/tests" },
 					{ "name": "dojo", "location": "node_modules/intern/browser_modules/dojo" },
 					{ "name": "@dojo", "location": "node_modules/@dojo" },
-					{ "name": "grunt-dojo2", "location": "node_modules/grunt-dojo2" },
 					{ "name": "maquette", "location": "node_modules/maquette/dist", "main": "maquette" },
 					{ "name": "sinon", "location": "node_modules/sinon/pkg", "main": "sinon" }
 				]

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "@types/sinon": "~1.16.0",
     "grunt": "~1.0.1",
     "grunt-dojo2": "latest",
-    "intern": "^4.0.2",
-    "istanbul": "^0.4.5",
+    "intern": "~4.0.2",
     "sinon": "^1.17.4",
     "typescript": "~2.4.1"
   }


### PR DESCRIPTION
**Type:** enhancement

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

`grunt-dojo2` has been updated in [a PR](https://github.com/dojo/grunt-dojo2/pull/162) to use Intern 4 exclusively which includes a reporter similar to the one developed for Intern 3. This PR updates the CI scripts to use these features and return the grunt tasks back to feature parity with the tasks before the Intern 4 conversion. The `grunt-dojo2` PR **MUST LAND** and be released before this can land.