### PR TITLE
Multiple outlets

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ const FooOutlet = Outlet(MyViewWidget, 'foo', (options: MapParamsOptions) {
 });
 ```
 
+
+When there are multiple matching outlets, the callback function receives all matching parameters merged into a single object.
+
 ##### Global Error Outlet
 
 Whenever a `MatchType.ERROR` occurs a global outlet is automatically added to the matched outlets called `errorOutlet`. This outlet can be used to render a widget for any unknown routes.
@@ -227,6 +230,8 @@ router.link('foo')
 ```
 
 A default route can be specified using the optional configuration property `defaultRoute`, which will be used if the current route does not match a registered route. Note there can only be one default route configured otherwise an error will be thrown.
+
+In the case that multiple outlets match, for example where a nested path has an exact match, and a parent path has a partial match, the deepest registered outlet is returned.
 
 #### Registering Additional Routes
 

--- a/src/Outlet.ts
+++ b/src/Outlet.ts
@@ -30,7 +30,7 @@ export type Outlet<
 
 export function Outlet<W extends WidgetBaseInterface, F extends WidgetBaseInterface, E extends WidgetBaseInterface>(
 	outletComponents: Component<W> | OutletComponents<W, F, E>,
-	outlet: string | Array<String>,
+	outlet: string | string[],
 	mapParams: MapParams = (options: MapParamsOptions) => {},
 	key: RegistryLabel = routerKey
 ): Outlet<W, F, E> {

--- a/src/Outlet.ts
+++ b/src/Outlet.ts
@@ -30,7 +30,7 @@ export type Outlet<
 
 export function Outlet<W extends WidgetBaseInterface, F extends WidgetBaseInterface, E extends WidgetBaseInterface>(
 	outletComponents: Component<W> | OutletComponents<W, F, E>,
-	outlet: string,
+	outlet: string | Array<String>,
 	mapParams: MapParams = (options: MapParamsOptions) => {},
 	key: RegistryLabel = routerKey
 ): Outlet<W, F, E> {

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -3,7 +3,7 @@ import Evented from '@dojo/core/Evented';
 import { assign } from '@dojo/shim/object';
 import { pausable, PausableHandle } from '@dojo/core/on';
 import UrlSearchParams from '@dojo/core/UrlSearchParams';
-import { includes } from '@dojo/shim/array';
+import { includes, find } from '@dojo/shim/array';
 import { Thenable } from '@dojo/shim/interfaces';
 import Map from '@dojo/shim/Map';
 import Promise from '@dojo/shim/Promise';
@@ -439,8 +439,19 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 		return this._outletContextMap.has(outletId);
 	}
 
-	getOutlet(outletId: string): OutletContext | undefined {
-		return this._outletContextMap.get(outletId);
+	getOutlet(outletId: string | Array<String>): OutletContext | undefined {
+		if (Array.isArray(outletId)) {
+			const outletContextArray = Array.from(this._outletContextMap);
+			const outlets = Array.from(outletId);
+
+			const matchingOutlet = find(outletContextArray, ([key]) => {
+				return includes(outlets, key);
+			});
+
+			return matchingOutlet ? matchingOutlet[1] : undefined;
+		} else {
+			return this._outletContextMap.get(outletId);
+		}
 	}
 
 	getCurrentParams(): Parameters {

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -3,7 +3,7 @@ import Evented from '@dojo/core/Evented';
 import { assign } from '@dojo/shim/object';
 import { pausable, PausableHandle } from '@dojo/core/on';
 import UrlSearchParams from '@dojo/core/UrlSearchParams';
-import { includes, find } from '@dojo/shim/array';
+import { includes, find, from as arrayFrom } from '@dojo/shim/array';
 import { Thenable } from '@dojo/shim/interfaces';
 import Map from '@dojo/shim/Map';
 import Promise from '@dojo/shim/Promise';
@@ -441,8 +441,8 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 
 	getOutlet(outletId: string | Array<String>): OutletContext | undefined {
 		if (Array.isArray(outletId)) {
-			const outletContextArray = Array.from(this._outletContextMap);
-			const outlets = Array.from(outletId);
+			const outletContextArray = arrayFrom(this._outletContextMap);
+			const outlets = arrayFrom(outletId);
 
 			const matchingOutlet = find(outletContextArray, ([key]) => {
 				return includes(outlets, key);

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -439,19 +439,18 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 		return this._outletContextMap.has(outletId);
 	}
 
-	getOutlet(outletId: string | Array<String>): OutletContext | undefined {
+	getOutlet(outletId: string | string[]): OutletContext | undefined {
 		if (Array.isArray(outletId)) {
 			const outletContextArray = arrayFrom(this._outletContextMap);
-			const outlets = arrayFrom(outletId);
 
 			const matchingOutlet = find(outletContextArray, ([key]) => {
-				return includes(outlets, key);
+				return includes(outletId, key);
 			});
 
 			return matchingOutlet ? matchingOutlet[1] : undefined;
-		} else {
-			return this._outletContextMap.get(outletId);
 		}
+
+		return this._outletContextMap.get(outletId);
 	}
 
 	getCurrentParams(): Parameters {

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -439,18 +439,36 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 		return this._outletContextMap.has(outletId);
 	}
 
-	getOutlet(outletId: string | string[]): OutletContext | undefined {
-		if (Array.isArray(outletId)) {
-			const outletContextArray = arrayFrom(this._outletContextMap);
+	getOutlet(outletIds: string | string[]): OutletContext | undefined {
+		if (Array.isArray(outletIds)) {
+			const combinedParams = outletIds.reduce((params, cur, index) => {
+				const context = this._outletContextMap.get(cur);
 
-			const matchingOutlet = find(outletContextArray, ([key]) => {
-				return includes(outletId, key);
-			});
+				if (context) {
+					return {
+						...params,
+						...context.params
+					};
+				}
 
-			return matchingOutlet ? matchingOutlet[1] : undefined;
+				return params;
+			}, {});
+
+			const outletContextArray = arrayFrom(this._outletContextMap) || [];
+
+			const [, matchingOutlet = undefined] = find(outletContextArray.reverse(), ([key]) => {
+				return includes(outletIds, key);
+			}) || [];
+
+			if (matchingOutlet) {
+				return {
+					...matchingOutlet,
+					params: combinedParams
+				};
+			}
+		} else {
+			return this._outletContextMap.get(outletIds);
 		}
-
-		return this._outletContextMap.get(outletId);
 	}
 
 	getCurrentParams(): Parameters {

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -440,7 +440,7 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 	}
 
 	getOutlet(outletId: string | string[]): OutletContext | undefined {
-		const outletIds = Array.isArray(outletId) ? outletId : [outletId];
+		const outletIds = Array.isArray(outletId) ? outletId : [ outletId ];
 		let matchingOutlet: OutletContext | undefined = undefined;
 		let matchingParams: Parameters = {};
 		let matchingLocation = '';

--- a/tests/unit/Router.ts
+++ b/tests/unit/Router.ts
@@ -509,10 +509,18 @@ suite('Router', () => {
 			outlet: 'outlet-id-1'
 		}, {
 			path: '/path-2',
-			outlet: 'outlet-id-2'
+			outlet: 'outlet-id-2',
+			children: [{
+				path: '/nested-path',
+				outlet: 'outlet-id-3',
+				children: [{
+					path: '/nested-path',
+					outlet: 'outlet-id-4'
+				}]
+			}]
 		}, {
 			path: '/path-3',
-			outlet: 'outlet-id-3'
+			outlet: 'outlet-id-5'
 		}];
 
 		const router = new Router({ config });
@@ -533,6 +541,30 @@ suite('Router', () => {
 
 		const emptyInput = router.getOutlet([]);
 		assert.equal(emptyInput, undefined);
+
+		await router.dispatch({}, '/path-2/nested-path');
+
+		const multipleMatchingOutlets = router.getOutlet(['outlet-id-2', 'outlet-id-3']);
+
+		assert.deepEqual(multipleMatchingOutlets, {
+			location: '/path-2',
+			type: MatchType.PARTIAL,
+			params: {}
+		});
+
+		await router.dispatch({}, '/path-2/nested-path/nested-path');
+
+		assert.deepEqual(router.getOutlet(['outlet-id-4']), {
+			location: '/path-2/nested-path/nested-path',
+			type: MatchType.INDEX,
+			params: {}
+		});
+
+		assert.deepEqual(router.getOutlet(['outlet-id-4', 'outlet-id-2']), {
+			location: '/path-2',
+			type: MatchType.PARTIAL,
+			params: {}
+		});
 	});
 
 	test('register() throws error if more than one default route is attempted to be registered', () => {

--- a/tests/unit/Router.ts
+++ b/tests/unit/Router.ts
@@ -515,7 +515,11 @@ suite('Router', () => {
 				outlet: 'outlet-id-3',
 				children: [{
 					path: '/nested-path',
-					outlet: 'outlet-id-4'
+					outlet: 'outlet-id-4',
+					children: [{
+						path: '/nested-path',
+						outlet: 'outlet-id-5'
+					}]
 				}]
 			}]
 		}, {
@@ -547,8 +551,8 @@ suite('Router', () => {
 		const multipleMatchingOutlets = router.getOutlet(['outlet-id-2', 'outlet-id-3']);
 
 		assert.deepEqual(multipleMatchingOutlets, {
-			location: '/path-2',
-			type: MatchType.PARTIAL,
+			location: '/path-2/nested-path',
+			type: MatchType.INDEX,
 			params: {}
 		});
 
@@ -561,9 +565,42 @@ suite('Router', () => {
 		});
 
 		assert.deepEqual(router.getOutlet(['outlet-id-4', 'outlet-id-2']), {
-			location: '/path-2',
-			type: MatchType.PARTIAL,
+			location: '/path-2/nested-path/nested-path',
+			type: MatchType.INDEX,
 			params: {}
+		});
+	});
+
+	test('parameters are combined with multiple matching outlets', async () => {
+		const config = [{
+			path: '/path',
+			outlet: 'outlet-id-1',
+			children: [{
+				path: '/nested-path/{outlet-2-param}',
+				outlet: 'outlet-id-2',
+				children: [{
+					path: '/nested-path/{outlet-3-param}',
+					outlet: 'outlet-id-3',
+					children: [{
+						path: '/nested-path/{outlet-4-param}',
+						outlet: 'outlet-id-4'
+					}]
+				}]
+			}]
+		}];
+
+		const router = new Router({ config });
+
+		await router.dispatch({}, '/path/nested-path/param-2/nested-path/param-3/nested-path/param-4');
+
+		assert.deepEqual(router.getOutlet(['outlet-id-3', 'outlet-id-2', 'outlet-id-4']), {
+			location: '/path/nested-path/param-2/nested-path/param-3/nested-path/param-4',
+			type: MatchType.INDEX,
+			params: {
+				'outlet-2-param': 'param-2',
+				'outlet-3-param': 'param-3',
+				'outlet-4-param': 'param-4'
+			}
 		});
 	});
 

--- a/tests/unit/Router.ts
+++ b/tests/unit/Router.ts
@@ -1,9 +1,9 @@
 import Task from '@dojo/core/async/Task';
-import Promise from '@dojo/shim/Promise';
 const { beforeEach, suite, test } = intern.getInterface('tdd');
 const { assert } = intern.getPlugin('chai');
 import { spy, stub } from 'sinon';
 import MemoryHistory from '../../src/history/MemoryHistory';
+
 import {
 	Context,
 	DefaultParameters,
@@ -501,6 +501,38 @@ suite('Router', () => {
 				type: MatchType.INDEX
 			});
 		});
+	});
+
+	test('query for multiple outlets', async () => {
+		const config = [{
+			path: '/path-1',
+			outlet: 'outlet-id-1'
+		}, {
+			path: '/path-2',
+			outlet: 'outlet-id-2'
+		}, {
+			path: '/path-3',
+			outlet: 'outlet-id-3'
+		}];
+
+		const router = new Router({ config });
+
+		await router.dispatch({}, '/path-2');
+
+		const noMatchResult = router.getOutlet(['no', 'outlet-id-1', '', ' ']);
+
+		assert.equal(noMatchResult, undefined);
+
+		const matchingResult = router.getOutlet(['true', 'outlet-id-2']);
+
+		assert.deepEqual(matchingResult, {
+			location: '/path-2',
+			type: MatchType.INDEX,
+			params: {}
+		});
+
+		const emptyInput = router.getOutlet([]);
+		assert.equal(emptyInput, undefined);
 	});
 
 	test('register() throws error if more than one default route is attempted to be registered', () => {


### PR DESCRIPTION
**Type:**  feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md) - I thought automated linting picks this up?
* [x] Unit or Functional tests are included in the PR

**Description:**

Enhance `getOutlet` so it can receive a single outlet ID or an array of outlet IDs.

Resolves #103 
