### PR TITLE
Gracefully fail if a link cannot be generated

### DIFF
--- a/src/Link.ts
+++ b/src/Link.ts
@@ -16,12 +16,7 @@ export interface LinkProperties extends VirtualDomProperties {
 
 const getProperties = (router: Router<any>, properties: any): Partial<LinkProperties> => {
 	const { to, isOutlet = true, params = {}, onClick, ...props } = properties;
-	let href: string | undefined;
-	try {
-		href = isOutlet ? router.link(to, { ...router.getCurrentParams(), ...params }) : to;
-	} catch (err) {
-
-	}
+	const href = isOutlet ? router.link(to, { ...router.getCurrentParams(), ...params }) : to;
 	const handleOnClick = (event: MouseEvent) => {
 
 		if (onClick) {
@@ -33,6 +28,7 @@ const getProperties = (router: Router<any>, properties: any): Partial<LinkProper
 			router.setPath(href);
 		}
 	};
+
 	return {
 		href,
 		onClick: handleOnClick,

--- a/src/Link.ts
+++ b/src/Link.ts
@@ -23,9 +23,11 @@ const getProperties = (router: Router<any>, properties: any): Partial<LinkProper
 			onClick(event);
 		}
 
-		if (!event.defaultPrevented && event.button === 0 && !properties.target && typeof href === 'string') {
+		if (!event.defaultPrevented && event.button === 0 && !properties.target) {
 			event.preventDefault();
-			router.setPath(href);
+			if (typeof href === 'string') {
+				router.setPath(href);
+			}
 		}
 	};
 

--- a/src/Link.ts
+++ b/src/Link.ts
@@ -14,16 +14,21 @@ export interface LinkProperties extends VirtualDomProperties {
 	to: string;
 }
 
-const getProperties = (router: Router<any>, properties: any): LinkProperties => {
+const getProperties = (router: Router<any>, properties: any): Partial<LinkProperties> => {
 	const { to, isOutlet = true, params = {}, onClick, ...props } = properties;
-	const href = isOutlet ? router.link(to, { ...router.getCurrentParams(), ...params }) : to;
+	let href: string | undefined;
+	try {
+		href = isOutlet ? router.link(to, { ...router.getCurrentParams(), ...params }) : to;
+	} catch (err) {
+
+	}
 	const handleOnClick = (event: MouseEvent) => {
 
 		if (onClick) {
 			onClick(event);
 		}
 
-		if (!event.defaultPrevented && event.button === 0 && !properties.target) {
+		if (!event.defaultPrevented && event.button === 0 && !properties.target && typeof href === 'string') {
 			event.preventDefault();
 			router.setPath(href);
 		}

--- a/src/Route.ts
+++ b/src/Route.ts
@@ -189,7 +189,7 @@ export class Route<C extends Context, P extends Parameters> implements RouteInte
 		}
 	}
 
-	link(params?: LinkParams): string {
+	link(params?: LinkParams): string | undefined {
 		return findRouter(this).link(this, params);
 	}
 

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -296,7 +296,7 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 		}, cancel);
 	}
 
-	link(routeOrOutlet: RouteInterface<Context, Parameters> | string, params: LinkParams = {}): string {
+	link(routeOrOutlet: RouteInterface<Context, Parameters> | string, params: LinkParams = {}): string | undefined {
 		let route: RouteInterface<Context, Parameters>;
 		if (typeof routeOrOutlet === 'string') {
 			const item = this._outletRouteMap.get(routeOrOutlet);
@@ -304,7 +304,7 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 				route = item;
 			}
 			else {
-				throw new Error(`No outlet ${routeOrOutlet} has been registered`);
+				return undefined;
 			}
 		}
 		else {
@@ -315,8 +315,8 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 			hierarchy.unshift(parent);
 		}
 
-		if (!includes(this._routes, hierarchy[ 0 ])) {
-			throw new Error('Cannot generate link for route that is not in the hierarchy');
+		if (!includes(this._routes, hierarchy[0])) {
+			return undefined;
 		}
 
 		const { leadingSlash: addLeadingSlash } = hierarchy[ 0 ].path;
@@ -449,7 +449,7 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 			const outletContext = this._outletContextMap.get(outletIds[i]);
 
 			if (outletContext) {
-				const { params, location } = outletContext;
+				const { params, location = '' } = outletContext;
 				matchingParams = { ...matchingParams, ...params };
 
 				if (!matchingOutlet || matchingLocation.indexOf(location) === -1) {
@@ -543,7 +543,7 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 				redirecting = false;
 			}
 			else if (!success && this._defaultRoute) {
-				const normalizedPath = this._history.normalizePath(this.link(this._defaultRoute));
+				const normalizedPath = this._history.normalizePath(this.link(this._defaultRoute) || '');
 				this._dispatch(context, normalizedPath);
 			}
 		}

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -327,7 +327,7 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 				let currentPathValues: string[] | undefined;
 				let currentSearchParams: SearchParams | undefined;
 
-				const selection = this._currentSelection[ index ];
+				const selection = this._currentSelection[index];
 				if (selection && selection.route === route) {
 					currentPathValues = selection.rawPathValues;
 					currentSearchParams = selection.rawSearchParams;
@@ -350,7 +350,7 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 							}
 							else if (Array.isArray(value)) {
 								if (value.length === 1) {
-									segments.push(value[ 0 ]);
+									segments.push(value[0]);
 								}
 								else {
 									return undefined;
@@ -380,7 +380,7 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 							continue;
 						}
 
-						const value = params[ key ] || this._defaultParams[ key ] ;
+						const value = params[key] || this._defaultParams[key] ;
 						if (typeof value === 'string') {
 							searchParams.append(key, value);
 						}
@@ -390,7 +390,7 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 							}
 						}
 						else if (currentSearchParams) {
-							for (const item of currentSearchParams[ key ]) {
+							for (const item of currentSearchParams[key]) {
 								searchParams.append(key, item);
 							}
 						}

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -460,7 +460,7 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 				const { params, location } = outletContext;
 				matchingParams = { ...matchingParams, ...params };
 
-				if (!matchingOutlet || typeof location === 'undefined' || matchingLocation.indexOf(location) === -1) {
+				if (!matchingOutlet || typeof location === 'undefined' || typeof matchingLocation === 'undefined' || matchingLocation.indexOf(location) === -1) {
 					matchingLocation = location;
 					matchingOutlet = {
 						...outletContext,

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -451,16 +451,16 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 		const outletIds = Array.isArray(outletId) ? outletId : [ outletId ];
 		let matchingOutlet: OutletContext | undefined = undefined;
 		let matchingParams: Parameters = {};
-		let matchingLocation = '';
+		let matchingLocation: string | undefined = '';
 
 		for (let i = 0; i < outletIds.length; i++) {
 			const outletContext = this._outletContextMap.get(outletIds[i]);
 
 			if (outletContext) {
-				const { params, location = '' } = outletContext;
+				const { params, location } = outletContext;
 				matchingParams = { ...matchingParams, ...params };
 
-				if (!matchingOutlet || matchingLocation.indexOf(location) === -1) {
+				if (!matchingOutlet || typeof location === 'undefined' || matchingLocation.indexOf(location) === -1) {
 					matchingLocation = location;
 					matchingOutlet = {
 						...outletContext,

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -30,6 +30,7 @@ import {
 import { isNamedSegment, parse as parsePath } from './lib/path';
 import { hasBeenAppended, parentMap } from './lib/router';
 import { Route } from './Route';
+import { Url } from "intern/lib/browser/util";
 
 export const errorOutlet = 'errorOutlet';
 
@@ -321,10 +322,7 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 
 		const { leadingSlash: addLeadingSlash } = hierarchy[ 0 ].path;
 		let addTrailingSlash = false;
-		const segments: string[] = [];
-		const searchParams = new UrlSearchParams();
-
-		hierarchy
+		const segmentsAndSearchparams = hierarchy
 			.map((route, index) => {
 				const { path } = route;
 				let currentPathValues: string[] | undefined;
@@ -338,68 +336,79 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 
 				return { currentPathValues, currentSearchParams, path, route };
 			})
-			.forEach(({ currentPathValues, currentSearchParams, path, route }) => {
-				const { expectedSegments, searchParameters, trailingSlash } = path;
-				addTrailingSlash = trailingSlash;
+			.reduce((segmentsAndSearchParams, { currentPathValues, currentSearchParams, path, route }) => {
+				if (segmentsAndSearchParams) {
+					const { segments, searchParams } = segmentsAndSearchParams;
+					const { expectedSegments, searchParameters, trailingSlash } = path;
+					addTrailingSlash = trailingSlash;
 
-				let namedOffset = 0;
-				for (const segment of expectedSegments) {
-					if (isNamedSegment(segment)) {
-						const value = params[ segment.name ];
-						if (typeof value === 'string') {
-							segments.push(value);
-						}
-						else if (Array.isArray(value)) {
-							if (value.length === 1) {
-								segments.push(value[ 0 ]);
+					let namedOffset = 0;
+					for (const segment of expectedSegments) {
+						if (isNamedSegment(segment)) {
+							const value = params[ segment.name ];
+							if (typeof value === 'string') {
+								segments.push(value);
+							}
+							else if (Array.isArray(value)) {
+								if (value.length === 1) {
+									segments.push(value[ 0 ]);
+								}
+								else {
+									return undefined;
+								}
+							}
+							else if (currentPathValues) {
+								segments.push(currentPathValues[ namedOffset ]);
+							}
+							else if (route.defaultParams[ segment.name ]) {
+								segments.push(route.defaultParams[ segment.name ]);
+
 							}
 							else {
-								throw new TypeError(`Cannot generate link, multiple values for parameter '${segment.name}'`);
+								return undefined;
 							}
-						}
-						else if (currentPathValues) {
-							segments.push(currentPathValues[ namedOffset ]);
-						}
-						else if (route.defaultParams[ segment.name ]) {
-							segments.push(route.defaultParams[ segment.name ]);
-
+							namedOffset++;
 						}
 						else {
-							throw new Error(`Cannot generate link, missing parameter '${segment.name}'`);
+							segments.push(segment.literal);
 						}
-						namedOffset++;
 					}
-					else {
-						segments.push(segment.literal);
+
+					for (const key of searchParameters) {
+						// Don't repeat the search parameter if a previous route in the hierarchy has already appended
+						// it.
+						if (searchParams.has(key)) {
+							continue;
+						}
+
+						const value = params[ key ] || this._defaultParams[ key ] ;
+						if (typeof value === 'string') {
+							searchParams.append(key, value);
+						}
+						else if (Array.isArray(value)) {
+							for (const item of value) {
+								searchParams.append(key, item);
+							}
+						}
+						else if (currentSearchParams) {
+							for (const item of currentSearchParams[ key ]) {
+								searchParams.append(key, item);
+							}
+						}
+						else {
+							return undefined;
+						}
 					}
 				}
 
-				for (const key of searchParameters) {
-					// Don't repeat the search parameter if a previous route in the hierarchy has already appended
-					// it.
-					if (searchParams.has(key)) {
-						continue;
-					}
+				return segmentsAndSearchParams;
+			}, { segments: [] as string[], searchParams: new UrlSearchParams() });
 
-					const value = params[ key ] || this._defaultParams[ key ] ;
-					if (typeof value === 'string') {
-						searchParams.append(key, value);
-					}
-					else if (Array.isArray(value)) {
-						for (const item of value) {
-							searchParams.append(key, item);
-						}
-					}
-					else if (currentSearchParams) {
-						for (const item of currentSearchParams[ key ]) {
-							searchParams.append(key, item);
-						}
-					}
-					else {
-						throw new Error(`Cannot generate link, missing search parameter '${key}'`);
-					}
-				}
-			});
+		if (!segmentsAndSearchparams) {
+			return undefined;
+		}
+
+		const { segments, searchParams } = segmentsAndSearchparams;
 
 		let pathname = segments.join('/');
 		if (addLeadingSlash) {

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -30,7 +30,6 @@ import {
 import { isNamedSegment, parse as parsePath } from './lib/path';
 import { hasBeenAppended, parentMap } from './lib/router';
 import { Route } from './Route';
-import { Url } from "intern/lib/browser/util";
 
 export const errorOutlet = 'errorOutlet';
 

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -517,8 +517,8 @@ export class Router<C extends Context> extends Evented implements RouterInterfac
 			this._dispatchFromStart = true;
 
 			const context = this._contextFactory();
-			lastDispatch = this.dispatch(context, path).then((dispatchResult) => {
-				const { success, redirect = undefined } = dispatchResult || { success: false };
+			lastDispatch = this.dispatch(context, path).then(dispatchResult => {
+				const { success, redirect } = dispatchResult;
 				if (success && redirect !== undefined) {
 					redirectCount++;
 					if (redirectCount > 20) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -65,7 +65,7 @@ export interface OutletComponents<W extends WidgetBaseInterface, I extends Widge
 export interface MapParamsOptions {
 	params: any;
 	type: MatchType;
-	location: string;
+	location: string | undefined;
 	router: RouterInterface<any>;
 }
 
@@ -256,7 +256,7 @@ export interface OutletContext {
 	/**
 	 * The location of the route (link)
 	 */
-	location: string;
+	location: string | undefined;
 
 	/**
 	 * The params for the specific outlet
@@ -273,7 +273,7 @@ export interface RouterInterface<C extends Context> extends Evented {
 
 	dispatch(context: Context, path: string): Task<DispatchResult>;
 
-	link(routeOrOutlet: RouteInterface<Context, Parameters> | string, params?: LinkParams): string;
+	link(routeOrOutlet: RouteInterface<Context, Parameters> | string, params?: LinkParams): string | undefined;
 
 	replacePath(path: string): void;
 
@@ -392,7 +392,7 @@ export interface RouteInterface<C extends Context, P extends Parameters> {
 	readonly defaultParams: P;
 
 	append(add: RouteInterface<Context, Parameters> | RouteInterface<Context, Parameters>[]): void;
-	link(params?: LinkParams): string;
+	link(params?: LinkParams): string | undefined;
 	match(segments: string[], hasTrailingSlash: boolean, searchParams: UrlSearchParams): null | MatchResult<DefaultParameters | P>;
 	select(context: C, segments: string[], hasTrailingSlash: boolean, searchParams: UrlSearchParams): string | Selection[];
 }

--- a/tests/unit/Link.ts
+++ b/tests/unit/Link.ts
@@ -132,7 +132,7 @@ suite('Link', () => {
 		link.__setCoreProperties__({ bind: link,  baseRegistry: registry });
 		link.__setProperties__({ to: 'bar', isOutlet: true });
 		const vNode: any = link.__render__();
-		assert.strictEqual(vNode.vnodeSelector, 'a');
+		assert.strictEqual(vNode.tag, 'a');
 		assert.isUndefined(vNode.properties.href);
 	});
 });

--- a/tests/unit/Link.ts
+++ b/tests/unit/Link.ts
@@ -127,4 +127,12 @@ suite('Link', () => {
 			// nothing to see here
 		}
 	});
+	test('Gracefully handles not being able to generate a link', () => {
+		const link = new Link();
+		link.__setCoreProperties__({ bind: link,  baseRegistry: registry });
+		link.__setProperties__({ to: 'bar', isOutlet: true });
+		const vNode: any = link.__render__();
+		assert.strictEqual(vNode.vnodeSelector, 'a');
+		assert.isUndefined(vNode.properties.href);
+	});
 });

--- a/tests/unit/Link.ts
+++ b/tests/unit/Link.ts
@@ -115,6 +115,23 @@ suite('Link', () => {
 		dNode.properties.onclick.call(link, createMockEvent(true));
 		assert.isTrue(routerSetPathSpy.notCalled);
 	});
+	test('Prevents default but does no set router path when href is undefined', () => {
+		const link = new Link();
+		link.__setCoreProperties__({ bind: link, baseRegistry: registry });
+		link.__setProperties__({
+			to: undefined as any,
+			isOutlet: false,
+			registry
+		});
+		const dNode: any = link.__render__();
+		const event = createMockEvent();
+		assert.strictEqual(dNode.tag, 'a');
+		assert.isUndefined(dNode.properties.href);
+		assert.isFalse(event.defaultPrevented);
+		dNode.properties.onclick.call(link, event);
+		assert.isTrue(routerSetPathSpy.notCalled);
+		assert.isTrue(event.defaultPrevented);
+	});
 	test('throw error if the injected router cannot be found with the router key', () => {
 		const link = new Link();
 		link.__setCoreProperties__({ bind: link, baseRegistry: registry });

--- a/tests/unit/Router.ts
+++ b/tests/unit/Router.ts
@@ -929,10 +929,10 @@ suite('Router', () => {
 	});
 
 	test('start() handles an invalid default route config', () => {
-		const history = new MemoryHistory({ path: '/foo' });
+		const history = new MemoryHistory();
 		const config = [
 			{
-				path: undefined as any,
+				path: '{bar}',
 				defaultRoute: true
 			}
 		];
@@ -944,7 +944,7 @@ suite('Router', () => {
 		});
 
 		router.start({ dispatchCurrent: true });
-		assert.deepEqual(dispatchedPaths, [ '/foo', '/' ]);
+		assert.deepEqual(dispatchedPaths, [ '', '' ]);
 	});
 
 	test('start() can be configured not to immediately dispatch for the current history value', () => {

--- a/tests/unit/Router.ts
+++ b/tests/unit/Router.ts
@@ -928,6 +928,25 @@ suite('Router', () => {
 		assert.deepEqual(dispatchedPaths, [ '/foo', 'bar' ]);
 	});
 
+	test('start() handles an invalid default route config', () => {
+		const history = new MemoryHistory({ path: '/foo' });
+		const config = [
+			{
+				path: undefined as any,
+				defaultRoute: true
+			}
+		];
+		const router = new Router({ history, config });
+		const dispatchedPaths: string[] = [];
+
+		router.on('navstart', (event) => {
+			dispatchedPaths.push(event.path);
+		});
+
+		router.start({ dispatchCurrent: true });
+		assert.deepEqual(dispatchedPaths, [ '/foo', '/' ]);
+	});
+
 	test('start() can be configured not to immediately dispatch for the current history value', () => {
 		const history = new MemoryHistory({ path: '/foo' });
 		const router = new Router({ history });

--- a/tests/unit/Router.ts
+++ b/tests/unit/Router.ts
@@ -1287,7 +1287,7 @@ suite('Router', () => {
 		history.set('/initial/foo');
 
 		return ready.then(link => {
-			assert.isUndefined(link);
+				assert.isUndefined(link);
 		});
 	});
 
@@ -1321,13 +1321,9 @@ suite('Router', () => {
 		router.start({ dispatchCurrent: false });
 		history.set('/initial/foo');
 
-		return ready
-			.then(() => {
-				throw new Error('Should have thrown');
-			})
-			.catch((err) => {
-				assert.equal(err.message, 'Cannot generate link, missing parameter \'foo\'');
-			});
+		return ready.then(link => {
+			assert.isUndefined(link);
+		});
 	});
 
 	test('there is no currently selected route for link() after an unmanaged dispatch', () => {

--- a/tests/unit/Router.ts
+++ b/tests/unit/Router.ts
@@ -1356,13 +1356,9 @@ suite('Router', () => {
 		router.start({ dispatchCurrent: false });
 		history.set('/initial/foo');
 
-		return ready
-			.then(() => {
-				throw new Error('Should have thrown');
-			})
-			.catch((err) => {
-				assert.equal(err.message, 'Cannot generate link, missing parameter \'foo\'');
-			});
+		return ready.then(link => {
+			assert.isUndefined(link);
+		});
 	});
 
 	test('link() generated for a registered outlet', () => {

--- a/tests/unit/Router.ts
+++ b/tests/unit/Router.ts
@@ -1286,13 +1286,9 @@ suite('Router', () => {
 		router.start({ dispatchCurrent: false });
 		history.set('/initial/foo');
 
-		return ready
-			.then(() => {
-				throw new Error('Should have thrown');
-			})
-			.catch((err) => {
-				assert.equal(err.message, 'Cannot generate link, missing parameter \'foo\'');
-			});
+		return ready.then(link => {
+			assert.isUndefined(link);
+		});
 	});
 
 	test('there is no currently selected route for link() after a dispatch fails', () => {

--- a/tests/unit/Router.ts
+++ b/tests/unit/Router.ts
@@ -1149,10 +1149,20 @@ suite('Router', () => {
 	test('link() returns undefined if more than one value is provided for a path parameter', () => {
 		const router = new Router();
 		const route = new Route({ path: '/{foo}' });
-		router.append(route);
 
+		router.append(route);
 		assert.equal(router.link(route, { foo: [ 'foo' ] }), '/foo');
-		assert.isUndefined(router.link(route, { foo: [ 'foo', 'bar' ] }), 'Cannot generate link, multiple values for parameter \'foo\'');
+		assert.isUndefined(router.link(route, { foo: [ 'foo', 'bar' ] }));
+	});
+
+	test('link() should return undefined if the parent route returns undefined', () => {
+		const router = new Router();
+		const route = new Route({ path: '/{foo}' });
+		const childRoute = new Route({ path: 'bar'});
+
+		router.append(route);
+		route.append(childRoute);
+		assert.isUndefined(router.link(childRoute, { foo: [ 'foo', 'bar' ]}));
 	});
 
 	test('link() fills in parameters', () => {

--- a/tests/unit/Router.ts
+++ b/tests/unit/Router.ts
@@ -1100,22 +1100,19 @@ suite('Router', () => {
 		assert.deepEqual(contexts[1], { second: true });
 	});
 
-	test('link() throws if route has not been appended', () => {
+	test('link() returns undefined if route has not been appended', () => {
 		const router = new Router();
-		assert.throws(() => {
-			router.link(new Route({ path: '/' }));
-		}, Error, 'Cannot generate link for route that is not in the hierarchy');
-		assert.throws(() => {
-			const foo = new Route({ path: '/foo' });
-			const bar = new Route({ path: '/bar' });
-			foo.append(bar);
-			router.link(bar);
-		}, Error, 'Cannot generate link for route that is not in the hierarchy');
-		assert.throws(() => {
-			const foo = new Route({ path: '/foo' });
-			new Router().append(foo);
-			router.link(foo);
-		}, Error, 'Cannot generate link for route that is not in the hierarchy');
+		const bar = new Route({ path: '/bar' });
+		let foo = new Route({ path: '/foo' });
+
+		assert.isUndefined(router.link(new Route({ path: '/' })), 'Cannot generate link for route that is not in the hierarchy');
+
+		foo.append(bar);
+		assert.isUndefined(router.link(bar), 'Cannot generate link for route that is not in the hierarchy');
+
+		foo = new Route({ path: '/foo' });
+		new Router().append(foo);
+		assert.isUndefined(router.link(foo), 'Cannot generate link for route that is not in the hierarchy');
 	});
 
 	test('link() combines paths of route hierarchy (no parameters)', () => {
@@ -1140,28 +1137,22 @@ suite('Router', () => {
 		assert.equal(router.link(route), '/prefixed/foo');
 	});
 
-	test('link() throws if parameters are missing', () => {
+	test('link() returns undefined if parameters are missing', () => {
 		const router = new Router();
 		const route = new Route({ path: '/{foo}?{bar}' });
 		router.append(route);
 
-		assert.throws(() => {
-			router.link(route);
-		}, Error, 'Cannot generate link, missing parameter \'foo\'');
-		assert.throws(() => {
-			router.link(route, { foo: 'foo' });
-		}, Error, 'Cannot generate link, missing search parameter \'bar\'');
+		assert.isUndefined(router.link(route), 'Cannot generate link, missing parameter \'foo\'');
+		assert.isUndefined(router.link(route, { foo: 'foo' }), 'Cannot generate link, missing search parameter \'bar\'');
 	});
 
-	test('link() throws if more than one value is provided for a path parameter', () => {
+	test('link() returns undefined if more than one value is provided for a path parameter', () => {
 		const router = new Router();
 		const route = new Route({ path: '/{foo}' });
 		router.append(route);
 
 		assert.equal(router.link(route, { foo: [ 'foo' ] }), '/foo');
-		assert.throws(() => {
-			router.link(route, { foo: [ 'foo', 'bar' ] });
-		}, Error, 'Cannot generate link, multiple values for parameter \'foo\'');
+		assert.isUndefined(router.link(route, { foo: [ 'foo', 'bar' ] }), 'Cannot generate link, multiple values for parameter \'foo\'');
 	});
 
 	test('link() fills in parameters', () => {
@@ -1235,7 +1226,7 @@ suite('Router', () => {
 		router.append(initial);
 
 		const ready = new Promise((resolve) => {
-			const links: string[] = [];
+			const links: (string | undefined)[] = [];
 			const route = new Route({
 				path: '/{foo}',
 				guard() {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Returns an `a` element without an href instead of throwing an error if a link cannot be generated. I believe this is what was intended from the issue description.

Resolves #104 
