### PR TITLE
Add Prettier with tslint plugin and precommit hook

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 The following has been addressed in the PR:
 
 * [ ] There is a related issue
-* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
+* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
 * [ ] Unit or Functional tests are included in the PR
 
 <!--

--- a/README.md
+++ b/README.md
@@ -1110,7 +1110,17 @@ Errors that occur during dispatch are emitted under the `error` event. The event
 ## How do I contribute?
 
 We appreciate your interest!  Please see the [Dojo 2 Meta Repository](https://github.com/dojo/meta#readme) for the
-Contributing Guidelines and Style Guide.
+Contributing Guidelines.
+
+### Code Style
+
+This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the projects `package.json`.
+
+An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
+
+```bash
+npm run prettier
+```
 
 ### Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7942,23 +7942,50 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.2.0.tgz",
-      "integrity": "sha1-FqKt3yDLdIOF9UTpoO2rCGvDQRQ=",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.8.0.tgz",
+      "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
-        "colors": "1.1.2",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
         "diff": "3.4.0",
-        "findup-sync": "0.3.0",
         "glob": "7.1.2",
-        "optimist": "0.6.1",
+        "minimatch": "3.0.4",
         "resolve": "1.5.0",
         "semver": "5.4.1",
         "tslib": "1.8.1",
-        "tsutils": "1.9.1"
+        "tsutils": "2.13.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        },
         "diff": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
@@ -7979,6 +8006,12 @@
             "path-is-absolute": "1.0.1"
           }
         },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
         "resolve": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
@@ -7986,6 +8019,24 @@
           "dev": true,
           "requires": {
             "path-parse": "1.0.5"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "tsutils": {
+          "version": "2.13.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.13.1.tgz",
+          "integrity": "sha512-XMOEvc2TiYesVSOJMI7OYPnBMSgcvERuGW5Li/J+2A0TuH607BPQnOLQ82oSPZCssB8c9+QGi6qhTBa/f1xQRA==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.8.1"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "integrity": "sha512-sgqHsKraTjKDoLfWece/E/ip29CsV3z+vEDSIzuBSWtXDEau6/pDRhbhuSnxjBB1bvvB8Drn93xWkO+PqqQ0Dg==",
       "dev": true,
       "requires": {
-        "@types/yargs": "8.0.2"
+        "@types/yargs": "8.0.3"
       }
     },
     "@dojo/loader": {
@@ -39,7 +39,7 @@
       "requires": {
         "intersection-observer": "0.4.3",
         "pepjs": "0.4.3",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@theintern/digdug": {
@@ -54,7 +54,7 @@
         "@dojo/shim": "0.2.3",
         "decompress": "4.2.0",
         "semver": "5.4.1",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@theintern/leadfoot": {
@@ -69,7 +69,7 @@
         "@dojo/shim": "0.2.3",
         "@types/jszip": "0.0.33",
         "jszip": "3.1.5",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@types/babel-types": {
@@ -91,13 +91,13 @@
       "dev": true,
       "requires": {
         "@types/express": "4.0.39",
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/chai": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.8.tgz",
-      "integrity": "sha512-m812CONwdZn/dMzkIJEY0yAs4apyTkTORgfB2UsMOxgkUbC205AHnm4T8I0I5gPg9MHrFc1dJ35iS75c0CJkjg==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.10.tgz",
+      "integrity": "sha512-Ejh1AXTY8lm+x91X/yar3G2z4x9RyKwdTVdyyu7Xj3dNB35fMNCnEWqTO9FgS3zjzlRNqk1MruYhgb8yhRN9rA==",
       "dev": true
     },
     "@types/charm": {
@@ -106,13 +106,19 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/diff": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-3.2.2.tgz",
       "integrity": "sha512-q3zfJvaTroV5BjAAR+peTHEGAAhGrPX0z2EzCzpt2mwFA+qzUn2nigJLqSekXRtdULKmT8am7zjvTMZSapIgHw==",
+      "dev": true
+    },
+    "@types/events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
       "dev": true
     },
     "@types/express": {
@@ -132,7 +138,7 @@
       "integrity": "sha512-QLAHjdLwEICm3thVbXSKRoisjfgMVI4xJH/HU8F385BR2HI7PmM6ax4ELXf8Du6sLmSpySXMYaI+xc//oQ/IFw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/fs-extra": {
@@ -141,17 +147,18 @@
       "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/glob": {
-      "version": "5.0.33",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
-      "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
+      "version": "5.0.34",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.34.tgz",
+      "integrity": "sha512-sUvpieq+HsWTLdkeOI8Mi8u22Ag3AoGuM3sv+XMP1bKtbaIAHpEA2f52K2mz6vK5PVhTa3bFyRZLZMqTxOo2Cw==",
       "dev": true,
       "requires": {
-        "@types/minimatch": "3.0.1",
-        "@types/node": "8.0.55"
+        "@types/events": "1.1.0",
+        "@types/minimatch": "3.0.2",
+        "@types/node": "8.5.1"
       }
     },
     "@types/grunt": {
@@ -160,7 +167,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/handlebars": {
@@ -240,9 +247,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.87",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.87.tgz",
-      "integrity": "sha512-AqRC+aEF4N0LuNHtcjKtvF9OTfqZI0iaBoe3dA6m/W+/YZJBZjBmW/QIZ8fBeXC6cnytSY9tBoFBqZ9uSCeVsw==",
+      "version": "4.14.91",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.91.tgz",
+      "integrity": "sha512-k+nc3moSlAaXacyvz4/c6D9lnUeI6AKsLvkXFuNzUEEqMw7sjDnLW2GqlJ4nyFgMX/p+QzvVG6zRoDo4lJIV5g==",
       "dev": true
     },
     "@types/marked": {
@@ -264,15 +271,15 @@
       "dev": true
     },
     "@types/minimatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz",
-      "integrity": "sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.2.tgz",
+      "integrity": "sha512-tctoxbfuMCxeI2CAsnwoZQfaBA+T7gPzDzDuiiFnyCSSyGYEB92cmRTh6E3tdR1hWsprbJ9IdbvX3PzLmJU/GA==",
       "dev": true
     },
     "@types/node": {
-      "version": "8.0.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.55.tgz",
-      "integrity": "sha512-K8w0FWNsIRcw615d/Et90wMRvLfg8XH1T77fC0xObbusE3+eXwnitdoF9j0CS9zBt8A57J/TKgRVe7RX9ZlT1g==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.1.tgz",
+      "integrity": "sha512-SrmAO+NhnsuG/6TychSl2VdxBZiw/d6V+8j+DFo8O3PwFi+QeYXWHhAw+b170aSc6zYab6/PjEWRZHIDN9mNUw==",
       "dev": true
     },
     "@types/platform": {
@@ -287,7 +294,7 @@
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/serve-static": {
@@ -312,7 +319,7 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/sinon": {
@@ -339,13 +346,13 @@
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/yargs": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.2.tgz",
-      "integrity": "sha512-Upj9YsBZRgjEVPvsaeGru48d2JiyzBNZkmkebHyoaQ+UM9wqj/rp5mkilRjSq/Ga45yfd/zwrNuML9f2gGfVpw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.3.tgz",
+      "integrity": "sha512-YdxO7zGQf2qJeMgR0fNO8QTlj88L2zCP5GOddovoTyetgLiNDOUXcWzhWKb4EdZZlOjLQUA0JM8lW7VcKQL+9w==",
       "dev": true
     },
     "abbrev": {
@@ -425,6 +432,21 @@
         "string-width": "2.1.1"
       }
     },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -435,6 +457,18 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
+    "any-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
+      "integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
       "dev": true
     },
     "any-promise": {
@@ -452,6 +486,12 @@
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
       }
+    },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+      "dev": true
     },
     "append-transform": {
       "version": "0.4.0",
@@ -585,7 +625,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000783",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -649,14 +689,14 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
           "dev": true
         }
       }
@@ -937,7 +977,7 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000783",
         "electron-to-chromium": "1.3.28"
       }
     },
@@ -1001,15 +1041,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000783",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000778",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000778.tgz",
-      "integrity": "sha1-Fnxg6VQqKqYFN8RG+ziB2FOjByo=",
+      "version": "1.0.30000783",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000783.tgz",
+      "integrity": "sha1-FrMNRyZqT1FcxprgMWtnDJYDzb4=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1094,6 +1134,12 @@
         "readdirp": "1.4.0"
       }
     },
+    "ci-info": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "dev": true
+    },
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
@@ -1108,6 +1154,53 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
+    },
+    "cli-spinners": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+      "dev": true
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
+      }
     },
     "cliui": {
       "version": "2.1.0",
@@ -1207,6 +1300,12 @@
       "requires": {
         "color-name": "1.1.3"
       }
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
     },
     "colormin": {
       "version": "1.1.2",
@@ -1345,6 +1444,45 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cosmiconfig": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+      "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+      "dev": true,
+      "requires": {
+        "is-directory": "0.3.1",
+        "js-yaml": "3.10.0",
+        "parse-json": "3.0.0",
+        "require-from-string": "2.0.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+          "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        }
+      }
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -1580,6 +1718,12 @@
         "array-find-index": "1.0.2"
       }
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
     "dateformat": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
@@ -1683,6 +1827,12 @@
           "dev": true
         }
       }
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -1842,6 +1992,12 @@
       "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
       "dev": true
     },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
+    },
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
@@ -1915,6 +2071,16 @@
         }
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz",
+      "integrity": "sha512-P0EohHM1MwL36GX5l1TOEYyt/5d7hcxrX3CqCjibTN3dH7VCAy2kjsC/WB6dUHnpB4mFkZq1Ndfh2DYQ2QMEGQ==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
+      }
+    },
     "esprima": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
@@ -1963,6 +2129,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "expand-brackets": {
@@ -2073,14 +2245,21 @@
       }
     },
     "fancy-log": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
         "time-stamp": "1.1.0"
       }
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2110,6 +2289,16 @@
       "dev": true,
       "requires": {
         "pend": "1.2.0"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "file-sync-cmp": {
@@ -2180,6 +2369,12 @@
           "dev": true
         }
       }
+    },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
     },
     "find-up": {
       "version": "1.1.2",
@@ -2350,6 +2545,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
       "dev": true
     },
     "get-stdin": {
@@ -2645,7 +2846,7 @@
         "grunt-ts": "5.5.1",
         "grunt-tslint": "4.0.1",
         "grunt-typings": "0.1.5",
-        "intern": "4.1.3",
+        "intern": "4.1.4",
         "istanbul-lib-coverage": "1.1.1",
         "istanbul-lib-report": "1.1.2",
         "istanbul-reports": "1.1.3",
@@ -2664,6 +2865,12 @@
         "umd-wrapper": "0.1.0"
       },
       "dependencies": {
+        "diff": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "dev": true
+        },
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -2678,11 +2885,34 @@
             "path-is-absolute": "1.0.1"
           }
         },
+        "grunt-tslint": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
+          "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+          "dev": true
+        },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
+        },
+        "tslint": {
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
+          "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "colors": "1.1.2",
+            "diff": "3.4.0",
+            "findup-sync": "0.3.0",
+            "glob": "7.1.2",
+            "optimist": "0.6.1",
+            "resolve": "1.1.7",
+            "tsutils": "1.9.1",
+            "update-notifier": "2.3.0"
+          }
         }
       }
     },
@@ -2809,9 +3039,9 @@
       }
     },
     "grunt-tslint": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
-      "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-5.0.1.tgz",
+      "integrity": "sha1-dDK9G9VuijolAACI1cYf3MNC8MI=",
       "dev": true
     },
     "grunt-typings": {
@@ -2834,7 +3064,7 @@
         "beeper": "1.1.1",
         "chalk": "1.1.3",
         "dateformat": "1.0.12",
-        "fancy-log": "1.3.0",
+        "fancy-log": "1.3.2",
         "gulplog": "1.0.0",
         "has-gulplog": "0.1.0",
         "lodash._reescape": "3.0.0",
@@ -3051,6 +3281,31 @@
         "extend": "3.0.1"
       }
     },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.0.10",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -3125,9 +3380,9 @@
       "dev": true
     },
     "intern": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.3.tgz",
-      "integrity": "sha512-IWaqzIwc+KQcoyiG+INvvv9L0fPKmgDSj+LySSWgnPc0VnYT1vgEmmxpwSlMPHDtfMMqq28/5/tsQVRx4EM2bQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.4.tgz",
+      "integrity": "sha512-QL5+pVjpjNVtp5mB2QwTgf3fuG3l+lA3UzhHTxjhahWt0Z84LfdFfHFXN6UeB72IYQq7LDhjStO6I51rsTjb6Q==",
       "dev": true,
       "requires": {
         "@dojo/core": "0.3.0",
@@ -3137,7 +3392,7 @@
         "@theintern/digdug": "2.0.4",
         "@theintern/leadfoot": "2.0.3",
         "@types/benchmark": "1.0.31",
-        "@types/chai": "4.0.8",
+        "@types/chai": "4.0.10",
         "@types/charm": "1.0.1",
         "@types/diff": "3.2.2",
         "@types/express": "4.0.39",
@@ -3148,7 +3403,7 @@
         "@types/istanbul-lib-report": "1.1.0",
         "@types/istanbul-lib-source-maps": "1.2.0",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.87",
+        "@types/lodash": "4.14.91",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -3178,7 +3433,7 @@
         "shell-quote": "1.6.1",
         "source-map": "0.5.7",
         "statuses": "1.3.1",
-        "tslib": "1.8.0",
+        "tslib": "1.8.1",
         "ws": "2.3.1"
       },
       "dependencies": {
@@ -3387,6 +3642,21 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.2"
+      }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -3472,6 +3742,15 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+      "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "0.2.4"
+      }
+    },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
@@ -3499,10 +3778,22 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
     "is-relative": {
@@ -3756,6 +4047,67 @@
         "handlebars": "4.0.11"
       }
     },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
+    },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true
+    },
+    "jest-validate": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "jest-get-type": "21.2.0",
+        "leven": "2.1.0",
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "js-base64": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
@@ -3886,6 +4238,12 @@
         "invert-kv": "1.0.0"
       }
     },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -3905,11 +4263,247 @@
         "immediate": "3.0.6"
       }
     },
+    "lint-staged": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-6.0.0.tgz",
+      "integrity": "sha512-ZUftK94S4vedpQG1LlA2tc2AuQXXBwc+1lB+j8SEfG5+p2dqu3Ug8iYQ8jdap+uLkhDw4OaJXqE+CZ/L+vfv+Q==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
+        "dedent": "0.7.0",
+        "execa": "0.8.0",
+        "find-parent-dir": "0.3.0",
+        "is-glob": "4.0.0",
+        "jest-validate": "21.2.1",
+        "listr": "0.13.0",
+        "lodash": "4.17.4",
+        "log-symbols": "2.1.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "path-is-inside": "1.0.2",
+        "pify": "3.0.0",
+        "staged-git-files": "0.0.4",
+        "stringify-object": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "listify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/listify/-/listify-1.0.0.tgz",
       "integrity": "sha1-A8p7otFQ1CZ3c/dOV1WNEFPSvuM=",
       "dev": true
+    },
+    "listr": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
+      "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-observable": "0.2.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.5",
+        "stream-to-observable": "0.2.0",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
+      }
     },
     "livereload-js": {
       "version": "2.2.2",
@@ -4094,6 +4688,62 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
+    },
+    "log-symbols": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
+      "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
+      }
     },
     "lolex": {
       "version": "1.3.2",
@@ -4420,6 +5070,15 @@
         "sort-keys": "1.1.2"
       }
     },
+    "npm-path": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
+      "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
+      "dev": true,
+      "requires": {
+        "which": "1.2.14"
+      }
+    },
     "npm-run-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
@@ -4427,6 +5086,25 @@
       "dev": true,
       "requires": {
         "path-key": "1.0.0"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "2.12.2",
+        "npm-path": "2.0.3",
+        "which": "1.2.14"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        }
       }
     },
     "num2fraction": {
@@ -4505,6 +5183,12 @@
       "integrity": "sha1-pT7D/xccNEYBbdUhDRobVEv32HQ=",
       "dev": true
     },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -4543,6 +5227,18 @@
           "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
+      }
+    },
+    "ora": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
       }
     },
     "os-homedir": {
@@ -4636,6 +5332,12 @@
       "requires": {
         "p-limit": "1.1.0"
       }
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
     },
     "package-json": {
       "version": "4.0.1",
@@ -5950,6 +6652,39 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
+      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
+      }
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -6249,9 +6984,9 @@
       "dev": true
     },
     "regenerator-runtime": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "regex-cache": {
@@ -6392,6 +7127,12 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -6409,6 +7150,16 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
       "dev": true
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
     },
     "resumer": {
       "version": "0.0.0",
@@ -6446,6 +7197,23 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
       "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
       "dev": true
+    },
+    "rxjs": {
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.5.tgz",
+      "integrity": "sha512-D/MfQnPMBk8P8gfwGxvCkuaWBcG58W7dUMT//URPoYzIbDEKT0GezdirkK5whMgKFBATfCoTpxO8bJQGJ04W5A==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -6643,6 +7411,12 @@
         "util": "0.10.3"
       }
     },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
@@ -6716,6 +7490,12 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "staged-git-files": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
+      "dev": true
+    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -6729,6 +7509,15 @@
       "dev": true,
       "requires": {
         "duplexer": "0.1.1"
+      }
+    },
+    "stream-to-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
+      "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
+      "dev": true,
+      "requires": {
+        "any-observable": "0.2.0"
       }
     },
     "strict-uri-encode": {
@@ -6781,6 +7570,17 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
+    },
+    "stringify-object": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz",
+      "integrity": "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -6869,6 +7669,12 @@
           }
         }
       }
+    },
+    "symbol-observable": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+      "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+      "dev": true
     },
     "tape": {
       "version": "2.3.0",
@@ -7130,15 +7936,15 @@
       "dev": true
     },
     "tslib": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-      "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=",
       "dev": true
     },
     "tslint": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
-      "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.2.0.tgz",
+      "integrity": "sha1-FqKt3yDLdIOF9UTpoO2rCGvDQRQ=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
@@ -7147,9 +7953,10 @@
         "findup-sync": "0.3.0",
         "glob": "7.1.2",
         "optimist": "0.6.1",
-        "resolve": "1.1.7",
-        "tsutils": "1.9.1",
-        "update-notifier": "2.3.0"
+        "resolve": "1.5.0",
+        "semver": "5.4.1",
+        "tslib": "1.8.1",
+        "tsutils": "1.9.1"
       },
       "dependencies": {
         "diff": {
@@ -7171,7 +7978,26 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
+        },
+        "resolve": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          }
         }
+      }
+    },
+    "tslint-plugin-prettier": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz",
+      "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-prettier": "2.4.0",
+        "tslib": "1.8.1"
       }
     },
     "tsutils": {
@@ -8408,7 +9234,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.87",
+        "@types/lodash": "4.14.91",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint-staged": "6.0.0",
     "prettier": "1.9.2",
     "sinon": "^1.17.4",
-    "tslint": "5.2.0",
+    "tslint": "5.8.0",
     "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   },
   "scripts": {
     "prepublish": "grunt peerDepInstall",
+    "precommit": "lint-staged",
+    "prettier": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
     "test": "grunt test"
   },
   "peerDependencies": {
@@ -39,8 +41,28 @@
     "@types/sinon": "~1.16.0",
     "grunt": "~1.0.1",
     "grunt-dojo2": "latest",
+    "grunt-tslint": "5.0.1",
+    "husky": "0.14.3",
     "intern": "~4.1.0",
+    "lint-staged": "6.0.0",
+    "prettier": "1.9.2",
     "sinon": "^1.17.4",
+    "tslint": "5.2.0",
+    "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "tabWidth": 4,
+    "useTabs": true,
+    "parser": "typescript",
+    "printWidth": 120,
+    "arrowParens": "always"
   }
 }

--- a/src/Link.ts
+++ b/src/Link.ts
@@ -18,7 +18,6 @@ const getProperties = (router: Router<any>, properties: any): LinkProperties => 
 	const { to, isOutlet = true, params = {}, onClick, ...props } = properties;
 	const href = isOutlet ? router.link(to, { ...router.getCurrentParams(), ...params }) : to;
 	const handleOnClick = (event: MouseEvent) => {
-
 		if (onClick) {
 			onClick(event);
 		}
@@ -36,13 +35,21 @@ const getProperties = (router: Router<any>, properties: any): LinkProperties => 
 };
 
 export class BaseLink extends WidgetBase<LinkProperties> {
-
 	private _onClick(event: MouseEvent): void {
 		this.properties.onClick && this.properties.onClick(event);
 	}
 
 	protected render(): DNode {
-		const props = { ...this.properties, onclick: this._onClick, onClick: undefined, to: undefined, isOutlet: undefined, params: undefined, routerKey: undefined, router: undefined };
+		const props = {
+			...this.properties,
+			onclick: this._onClick,
+			onClick: undefined,
+			to: undefined,
+			isOutlet: undefined,
+			params: undefined,
+			routerKey: undefined,
+			router: undefined
+		};
 		return v('a', { ...props }, this.children);
 	}
 }

--- a/src/Outlet.ts
+++ b/src/Outlet.ts
@@ -1,32 +1,23 @@
-import {
-	Constructor,
-	RegistryLabel,
-	DNode,
-	WidgetBaseInterface,
-	WidgetProperties
-} from '@dojo/widget-core/interfaces';
+import { Constructor, RegistryLabel, DNode, WidgetBaseInterface, WidgetProperties } from '@dojo/widget-core/interfaces';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { w } from '@dojo/widget-core/d';
 import { inject } from '@dojo/widget-core/decorators/inject';
 
 import { Router } from './Router';
 import { routerKey } from './RouterInjector';
-import {
-	MatchType,
-	Component,
-	MapParams,
-	OutletComponents,
-	MapParamsOptions
-} from './interfaces';
+import { MatchType, Component, MapParams, OutletComponents, MapParamsOptions } from './interfaces';
 
 export function isComponent<W extends WidgetBaseInterface>(value: any): value is Component<W> {
-	return Boolean(value && ((typeof value === 'string') || (typeof value === 'function') || (typeof value === 'symbol')));
+	return Boolean(value && (typeof value === 'string' || typeof value === 'function' || typeof value === 'symbol'));
 }
 
 export type Outlet<
 	W extends WidgetBaseInterface,
 	F extends WidgetBaseInterface,
-	E extends WidgetBaseInterface> = Constructor<WidgetBase<Partial<E['properties']> & Partial<W['properties']> & Partial<F['properties']> & WidgetProperties, null>>;
+	E extends WidgetBaseInterface
+> = Constructor<
+	WidgetBase<Partial<E['properties']> & Partial<W['properties']> & Partial<F['properties']> & WidgetProperties, null>
+>;
 
 export function Outlet<W extends WidgetBaseInterface, F extends WidgetBaseInterface, E extends WidgetBaseInterface>(
 	outletComponents: Component<W> | OutletComponents<W, F, E>,
@@ -43,7 +34,6 @@ export function Outlet<W extends WidgetBaseInterface, F extends WidgetBaseInterf
 
 	@inject({ name: routerKey, getProperties })
 	class OutletComponent extends WidgetBase<Partial<W['properties']> & { router: Router<any> }, null> {
-
 		public __setProperties__(properties: Partial<W['properties']> & { router: Router<any> }): void {
 			super.__setProperties__(properties);
 			this.invalidate();
@@ -58,11 +48,9 @@ export function Outlet<W extends WidgetBaseInterface, F extends WidgetBaseInterf
 
 				if ((type === MatchType.INDEX || type === MatchType.ERROR) && indexComponent) {
 					return w(indexComponent, properties, this.children);
-				}
-				else if (type === MatchType.ERROR && errorComponent) {
+				} else if (type === MatchType.ERROR && errorComponent) {
 					return w(errorComponent, properties, this.children);
-				}
-				else if (type !== MatchType.ERROR && mainComponent) {
+				} else if (type !== MatchType.ERROR && mainComponent) {
 					return w(mainComponent, properties, this.children);
 				}
 			}

--- a/src/Route.ts
+++ b/src/Route.ts
@@ -88,18 +88,22 @@ export interface RouteOptions<C extends Context, P extends Parameters> {
 // change the private state of their children.
 const parentMap = new WeakMap<Route<Context, Parameters>, Route<Context, Parameters>>();
 
-const noop = () => {
-};
+const noop = () => {};
 
-function computeDefaultParams(parameters: string[], searchParameters: string[], fromPathname: string[], searchParams: UrlSearchParams): null | DefaultParameters {
+function computeDefaultParams(
+	parameters: string[],
+	searchParameters: string[],
+	fromPathname: string[],
+	searchParams: UrlSearchParams
+): null | DefaultParameters {
 	const params: DefaultParameters = {};
 	parameters.forEach((name, index) => {
-		params[ name ] = fromPathname[ index ];
+		params[name] = fromPathname[index];
 	});
-	searchParameters.forEach(name => {
+	searchParameters.forEach((name) => {
 		const value = searchParams.get(name);
 		if (value !== undefined) {
-			params[ name ] = value;
+			params[name] = value;
 		}
 	});
 
@@ -135,10 +139,20 @@ export class Route<C extends Context, P extends Parameters> implements RouteInte
 	}
 
 	constructor(options: RouteOptions<C, P> = {}) {
-		const { exec, fallback, guard, index, params: computeParams, path, outlet, trailingSlashMustMatch = true, defaultParams = {} } = options;
+		const {
+			exec,
+			fallback,
+			guard,
+			index,
+			params: computeParams,
+			path,
+			outlet,
+			trailingSlashMustMatch = true,
+			defaultParams = {}
+		} = options;
 
 		if (path && /#/.test(path)) {
-			throw new TypeError('Path must not contain \'#\'');
+			throw new TypeError("Path must not contain '#'");
 		}
 
 		const deconstructedPath = deconstructPath(path || '/');
@@ -146,12 +160,11 @@ export class Route<C extends Context, P extends Parameters> implements RouteInte
 
 		if (computeParams) {
 			if (parameters.length === 0 && searchParameters.length === 0) {
-				throw new TypeError('Can\'t specify params() if path doesn\'t contain any');
+				throw new TypeError("Can't specify params() if path doesn't contain any");
 			}
 
 			this._computeParams = computeParams;
-		}
-		else {
+		} else {
 			this._computeParams = (fromPathname: string[], searchParams: UrlSearchParams) => {
 				return computeDefaultParams(parameters, searchParameters, fromPathname, searchParams);
 			};
@@ -164,7 +177,7 @@ export class Route<C extends Context, P extends Parameters> implements RouteInte
 		this._path = deconstructedPath;
 		this._outlet = outlet;
 		this._routes = [];
-		this._defaultParams = <P> defaultParams;
+		this._defaultParams = <P>defaultParams;
 		this._trailingSlashMustMatch = trailingSlashMustMatch;
 	}
 
@@ -182,8 +195,7 @@ export class Route<C extends Context, P extends Parameters> implements RouteInte
 			for (const route of add) {
 				append(route);
 			}
-		}
-		else {
+		} else {
 			append(add);
 		}
 	}
@@ -192,7 +204,11 @@ export class Route<C extends Context, P extends Parameters> implements RouteInte
 		return findRouter(this).link(this, params);
 	}
 
-	match(segments: string[], hasTrailingSlash: boolean, searchParams: UrlSearchParams): null | MatchResult<DefaultParameters | P> {
+	match(
+		segments: string[],
+		hasTrailingSlash: boolean,
+		searchParams: UrlSearchParams
+	): null | MatchResult<DefaultParameters | P> {
 		const result = matchPath(this._path, segments);
 		if (result === null) {
 			return null;
@@ -206,7 +222,7 @@ export class Route<C extends Context, P extends Parameters> implements RouteInte
 		const knownSearchParams = this._path.searchParameters.reduce<SearchParams>((list, name) => {
 			const value = searchParams.getAll(name);
 			if (value !== undefined) {
-				list[ name ] = value;
+				list[name] = value;
 			}
 			return list;
 		}, {});
@@ -225,11 +241,19 @@ export class Route<C extends Context, P extends Parameters> implements RouteInte
 		};
 	}
 
-	select(context: C, segments: string[], hasTrailingSlash: boolean, searchParams: UrlSearchParams): string | Selection[] {
+	select(
+		context: C,
+		segments: string[],
+		hasTrailingSlash: boolean,
+		searchParams: UrlSearchParams
+	): string | Selection[] {
 		const matchResult = this.match(segments, hasTrailingSlash, searchParams);
 
 		// Return early if possible.
-		if (!matchResult || matchResult.hasRemaining && this._routes.length === 0 && !this._fallback && !this._outlet) {
+		if (
+			!matchResult ||
+			(matchResult.hasRemaining && this._routes.length === 0 && !this._fallback && !this._outlet)
+		) {
 			return [];
 		}
 
@@ -272,9 +296,8 @@ export class Route<C extends Context, P extends Parameters> implements RouteInte
 				selected = true;
 				handler = this._fallback || noop;
 			}
-		}
-		// Select this route, configure the index handler if specified.
-		else {
+		} else {
+			// Select this route, configure the index handler if specified.
 			selected = true;
 			type = MatchType.INDEX;
 			if (this._index) {
@@ -303,7 +326,7 @@ export class Route<C extends Context, P extends Parameters> implements RouteInte
 			route: this,
 			type
 		};
-		return remainingSelection ? [ selection, ...remainingSelection ] : [ selection ];
+		return remainingSelection ? [selection, ...remainingSelection] : [selection];
 	}
 }
 

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -31,8 +31,7 @@ import { Route } from './Route';
 export const errorOutlet = 'errorOutlet';
 
 // istanbul ignore next
-const noop = () => {
-};
+const noop = () => {};
 
 function createDeferral() {
 	// Use noop since TypeScript doesn't know we're assigning cancel and resume in the promise executor.
@@ -56,7 +55,12 @@ function reportError<C extends Context>(router: Router<C>, context: C, path: str
 	});
 }
 
-function catchRejection<C extends Context>(router: Router<C>, context: C, path: string, thenable: void | PromiseLike<any>) {
+function catchRejection<C extends Context>(
+	router: Router<C>,
+	context: C,
+	path: string,
+	thenable: void | PromiseLike<any>
+) {
 	if (thenable) {
 		Promise.resolve(thenable).catch((error) => {
 			reportError(router, context, path, error);
@@ -64,7 +68,8 @@ function catchRejection<C extends Context>(router: Router<C>, context: C, path: 
 	}
 }
 
-export class Router<C extends Context, M extends RouterEventMap<C> = RouterEventMap<C>> extends Evented<M> implements RouterInterface<C> {
+export class Router<C extends Context, M extends RouterEventMap<C> = RouterEventMap<C>> extends Evented<M>
+	implements RouterInterface<C> {
 	private _contextFactory: () => C;
 	private _currentSelection: Selection[];
 	private _dispatchFromStart: boolean;
@@ -78,20 +83,18 @@ export class Router<C extends Context, M extends RouterEventMap<C> = RouterEvent
 	private _defaultParams: any = {};
 	private _defaultRoute: RouteInterface<any, any>;
 
-	constructor(options: RouterOptions<C> = { }) {
+	constructor(options: RouterOptions<C> = {}) {
 		super();
 		const { context, fallback, history, config } = options;
 
 		let contextFactory: () => C;
 		if (typeof context === 'function') {
 			contextFactory = context;
-		}
-		else if (typeof context === 'undefined') {
+		} else if (typeof context === 'undefined') {
 			contextFactory = () => {
 				return {} as C;
 			};
-		}
-		else {
+		} else {
 			// Assign to a constant since the context variable may be changed after the function is defined,
 			// which would violate its typing.
 			const sharedContext = context;
@@ -119,8 +122,7 @@ export class Router<C extends Context, M extends RouterEventMap<C> = RouterEvent
 		let parent: RouterInterface<any> | RouteInterface<any, any>;
 		if (typeof from === 'string') {
 			parent = this._outletRouteMap.get(from) || this;
-		}
-		else {
+		} else {
 			parent = from;
 		}
 
@@ -133,9 +135,10 @@ export class Router<C extends Context, M extends RouterEventMap<C> = RouterEvent
 			if (defaultRoute) {
 				if (!this._defaultRoute) {
 					this._defaultRoute = route;
-				}
-				else {
-					throw new Error(`Default outlet has already been configured. Unable to register outlet ${outlet} as the default.`);
+				} else {
+					throw new Error(
+						`Default outlet has already been configured. Unable to register outlet ${outlet} as the default.`
+					);
 				}
 			}
 			assign(this._defaultParams, defaultParams);
@@ -161,8 +164,7 @@ export class Router<C extends Context, M extends RouterEventMap<C> = RouterEvent
 			for (const route of add) {
 				append(route);
 			}
-		}
-		else {
+		} else {
 			append(add);
 		}
 	}
@@ -244,7 +246,6 @@ export class Router<C extends Context, M extends RouterEventMap<C> = RouterEvent
 			result.redirect = redirect;
 		}
 		return result;
-
 	}
 
 	dispatch(context: C, path: string): Task<DispatchResult> {
@@ -260,7 +261,7 @@ export class Router<C extends Context, M extends RouterEventMap<C> = RouterEvent
 		this.emit({
 			context,
 			cancel,
-			defer () {
+			defer() {
 				const { cancel, promise, resume } = createDeferral();
 				deferrals.push(promise);
 				return { cancel, resume };
@@ -277,17 +278,19 @@ export class Router<C extends Context, M extends RouterEventMap<C> = RouterEvent
 
 		return new Task<DispatchResult>((resolve, reject) => {
 			// *Always* start dispatching in a future turn, even if there were no deferrals.
-			Promise.all(deferrals).then<DispatchResult, DispatchResult>(
-				() => {
-					return this._dispatch(context, path, canceled, false);
-				},
-				() => {
-					return { success: false };
-				}
-			).then(resolve, (error) => {
-				reportError(this, context, path, error);
-				reject(error);
-			});
+			Promise.all(deferrals)
+				.then<DispatchResult, DispatchResult>(
+					() => {
+						return this._dispatch(context, path, canceled, false);
+					},
+					() => {
+						return { success: false };
+					}
+				)
+				.then(resolve, (error) => {
+					reportError(this, context, path, error);
+					reject(error);
+				});
 		}, cancel);
 	}
 
@@ -297,24 +300,22 @@ export class Router<C extends Context, M extends RouterEventMap<C> = RouterEvent
 			const item = this._outletRouteMap.get(routeOrOutlet);
 			if (item) {
 				route = item;
-			}
-			else {
+			} else {
 				throw new Error(`No outlet ${routeOrOutlet} has been registered`);
 			}
-		}
-		else {
+		} else {
 			route = routeOrOutlet;
 		}
-		const hierarchy = [ route ];
+		const hierarchy = [route];
 		for (let parent = route.parent; parent !== undefined; parent = parent.parent) {
 			hierarchy.unshift(parent);
 		}
 
-		if (!includes(this._routes, hierarchy[ 0 ])) {
+		if (!includes(this._routes, hierarchy[0])) {
 			throw new Error('Cannot generate link for route that is not in the hierarchy');
 		}
 
-		const { leadingSlash: addLeadingSlash } = hierarchy[ 0 ].path;
+		const { leadingSlash: addLeadingSlash } = hierarchy[0].path;
 		let addTrailingSlash = false;
 		const segments: string[] = [];
 		const searchParams = new UrlSearchParams();
@@ -325,7 +326,7 @@ export class Router<C extends Context, M extends RouterEventMap<C> = RouterEvent
 				let currentPathValues: string[] | undefined;
 				let currentSearchParams: SearchParams | undefined;
 
-				const selection = this._currentSelection[ index ];
+				const selection = this._currentSelection[index];
 				if (selection && selection.route === route) {
 					currentPathValues = selection.rawPathValues;
 					currentSearchParams = selection.rawSearchParams;
@@ -340,31 +341,26 @@ export class Router<C extends Context, M extends RouterEventMap<C> = RouterEvent
 				let namedOffset = 0;
 				for (const segment of expectedSegments) {
 					if (isNamedSegment(segment)) {
-						const value = params[ segment.name ];
+						const value = params[segment.name];
 						if (typeof value === 'string') {
 							segments.push(value);
-						}
-						else if (Array.isArray(value)) {
+						} else if (Array.isArray(value)) {
 							if (value.length === 1) {
-								segments.push(value[ 0 ]);
+								segments.push(value[0]);
+							} else {
+								throw new TypeError(
+									`Cannot generate link, multiple values for parameter '${segment.name}'`
+								);
 							}
-							else {
-								throw new TypeError(`Cannot generate link, multiple values for parameter '${segment.name}'`);
-							}
-						}
-						else if (currentPathValues) {
-							segments.push(currentPathValues[ namedOffset ]);
-						}
-						else if (route.defaultParams[ segment.name ]) {
-							segments.push(route.defaultParams[ segment.name ]);
-
-						}
-						else {
+						} else if (currentPathValues) {
+							segments.push(currentPathValues[namedOffset]);
+						} else if (route.defaultParams[segment.name]) {
+							segments.push(route.defaultParams[segment.name]);
+						} else {
 							throw new Error(`Cannot generate link, missing parameter '${segment.name}'`);
 						}
 						namedOffset++;
-					}
-					else {
+					} else {
 						segments.push(segment.literal);
 					}
 				}
@@ -376,21 +372,18 @@ export class Router<C extends Context, M extends RouterEventMap<C> = RouterEvent
 						continue;
 					}
 
-					const value = params[ key ] || this._defaultParams[ key ] ;
+					const value = params[key] || this._defaultParams[key];
 					if (typeof value === 'string') {
 						searchParams.append(key, value);
-					}
-					else if (Array.isArray(value)) {
+					} else if (Array.isArray(value)) {
 						for (const item of value) {
 							searchParams.append(key, item);
 						}
-					}
-					else if (currentSearchParams) {
-						for (const item of currentSearchParams[ key ]) {
+					} else if (currentSearchParams) {
+						for (const item of currentSearchParams[key]) {
 							searchParams.append(key, item);
 						}
-					}
-					else {
+					} else {
 						throw new Error(`Cannot generate link, missing search parameter '${key}'`);
 					}
 				}
@@ -435,7 +428,7 @@ export class Router<C extends Context, M extends RouterEventMap<C> = RouterEvent
 	}
 
 	getOutlet(outletId: string | string[]): OutletContext | undefined {
-		const outletIds = Array.isArray(outletId) ? outletId : [ outletId ];
+		const outletIds = Array.isArray(outletId) ? outletId : [outletId];
 		let matchingOutlet: OutletContext | undefined = undefined;
 		let matchingParams: Parameters = {};
 		let matchingLocation = '';
@@ -464,7 +457,7 @@ export class Router<C extends Context, M extends RouterEventMap<C> = RouterEvent
 		return this._currentParams;
 	}
 
-	start(startOptions: StartOptions = { dispatchCurrent : true }): PausableHandle {
+	start(startOptions: StartOptions = { dispatchCurrent: true }): PausableHandle {
 		const { dispatchCurrent } = startOptions;
 
 		if (this._started) {
@@ -475,12 +468,9 @@ export class Router<C extends Context, M extends RouterEventMap<C> = RouterEvent
 
 		if (!this._history) {
 			return {
-				pause() {
-				},
-				resume() {
-				},
-				destroy() {
-				}
+				pause() {},
+				resume() {},
+				destroy() {}
 			};
 		}
 
@@ -536,8 +526,7 @@ export class Router<C extends Context, M extends RouterEventMap<C> = RouterEvent
 				redirecting = true;
 				this._history!.replace(redirect);
 				redirecting = false;
-			}
-			else if (!success && this._defaultRoute) {
+			} else if (!success && this._defaultRoute) {
 				const normalizedPath = this._history.normalizePath(this.link(this._defaultRoute));
 				this._dispatch(context, normalizedPath);
 			}

--- a/src/RouterInjector.ts
+++ b/src/RouterInjector.ts
@@ -29,7 +29,11 @@ export interface RouterInjectorOptions {
  * @param registry An optional registry that defaults to the global registry
  * @param options The router injector options
  */
-export function registerRouterInjector(config: RouteConfig[], registry: Registry, options: RouterInjectorOptions = {}): Router<any> {
+export function registerRouterInjector(
+	config: RouteConfig[],
+	registry: Registry,
+	options: RouterInjectorOptions = {}
+): Router<any> {
 	const { key = routerKey, history = new HashHistory() } = options;
 
 	if (registry.hasInjector(key)) {

--- a/src/examples/ambigious-matches.ts
+++ b/src/examples/ambigious-matches.ts
@@ -12,13 +12,13 @@ export interface ChildProperties extends WidgetProperties {
 
 export class About extends WidgetBase {
 	render(): DNode {
-		return v('h2', [ 'About' ]);
+		return v('h2', ['About']);
 	}
 }
 
 export class Company extends WidgetBase {
 	render(): DNode {
-		return v('h2', [ 'Company' ]);
+		return v('h2', ['Company']);
 	}
 }
 
@@ -28,32 +28,24 @@ export interface UserProperties extends WidgetProperties {
 
 export class User extends WidgetBase<UserProperties> {
 	render(): DNode {
-		return v('div', [
-			v('h2', [ `User: ${this.properties.name}`])
-		]);
+		return v('div', [v('h2', [`User: ${this.properties.name}`])]);
 	}
 }
 
 export const AboutOutlet = Outlet(About, 'about');
 export const CompanyOutlet = Outlet(Company, 'company');
-export const UserOutlet = Outlet(User, 'user', ({ params }: MapParamsOptions) => { return { name: params.user }; });
+export const UserOutlet = Outlet(User, 'user', ({ params }: MapParamsOptions) => {
+	return { name: params.user };
+});
 
 export class App extends WidgetBase {
 	render(): DNode {
 		return v('div', [
 			v('ul', [
-				v('li', [
-					w(Link, { key: '1', to: 'about-us' }, [ 'About Us (Static)' ])
-				]),
-				v('li', [
-					w(Link, { key: '2', to: 'company' }, [ 'Company (Static)' ])
-				]),
-				v('li', [
-					w(Link, { key: '3', to: 'user', params: { user: 'kim' } }, [ 'Kim (dynamic)' ])
-				]),
-				v('li', [
-					w(Link, { key: '4', to: 'user', params: { user: 'chris' } }, [ 'Chris (dynamic)' ])
-				])
+				v('li', [w(Link, { key: '1', to: 'about-us' }, ['About Us (Static)'])]),
+				v('li', [w(Link, { key: '2', to: 'company' }, ['Company (Static)'])]),
+				v('li', [w(Link, { key: '3', to: 'user', params: { user: 'kim' } }, ['Kim (dynamic)'])]),
+				v('li', [w(Link, { key: '4', to: 'user', params: { user: 'chris' } }, ['Chris (dynamic)'])])
 			]),
 			w(AboutOutlet, {}),
 			w(CompanyOutlet, {}),

--- a/src/examples/basic.ts
+++ b/src/examples/basic.ts
@@ -12,17 +12,13 @@ export interface ChildProperties extends WidgetProperties {
 
 export class About extends WidgetBase {
 	render(): DNode {
-		return v('div', [
-			v('h2', [ 'About' ])
-		]);
+		return v('div', [v('h2', ['About'])]);
 	}
 }
 
 export class Home extends WidgetBase {
 	render(): DNode {
-		return v('div', [
-			v('h2', [ 'Home' ])
-		]);
+		return v('div', [v('h2', ['Home'])]);
 	}
 }
 
@@ -35,25 +31,17 @@ export class Topics extends WidgetBase<TopicsProperties> {
 		const { showHeading } = this.properties;
 
 		return v('div', [
-			v('h2', [ 'Topics' ]),
+			v('h2', ['Topics']),
 			v('ul', [
 				v('li', [
 					w(Link, { key: 'rendering', to: 'topic', params: { topic: 'rendering' } }, [
 						'Rendering with Dojo 2'
 					])
 				]),
-				v('li', [
-					w(Link, { key: 'widgets', to: 'topic', params: { topic: 'widgets' } }, [
-						'Widgets'
-					])
-				]),
-				v('li', [
-					w(Link, { key: 'props', to: 'topic', params: { topic: 'props-v-state' } }, [
-						'Props v State'
-					])
-				])
+				v('li', [w(Link, { key: 'widgets', to: 'topic', params: { topic: 'widgets' } }, ['Widgets'])]),
+				v('li', [w(Link, { key: 'props', to: 'topic', params: { topic: 'props-v-state' } }, ['Props v State'])])
 			]),
-			showHeading ? v('h3', [ 'Please select a topic.' ]) : null,
+			showHeading ? v('h3', ['Please select a topic.']) : null,
 			w(TopicOutlet, {})
 		]);
 	}
@@ -65,15 +53,13 @@ export interface TopicProperties extends WidgetProperties {
 
 export class Topic extends WidgetBase<TopicProperties> {
 	render(): DNode {
-		return v('div', [
-			v('h3', [ this.properties.topic ])
-		]);
+		return v('div', [v('h3', [this.properties.topic])]);
 	}
 }
 
 class ErrorWidget extends WidgetBase {
 	render() {
-		return v('div', [ 'ERROR 2' ]);
+		return v('div', ['ERROR 2']);
 	}
 }
 
@@ -90,15 +76,9 @@ export class App extends WidgetBase {
 	render(): DNode {
 		return v('div', [
 			v('ul', [
-				v('li', [
-					w(Link, { key: 'home', to: 'home' }, [ 'Home' ])
-				]),
-				v('li', [
-					w(Link, { key: 'about', to: 'about' }, [ 'About' ])
-				]),
-				v('li', [
-					w(Link, { key: 'topics', to: 'topics' }, [ 'Topics' ])
-				])
+				v('li', [w(Link, { key: 'home', to: 'home' }, ['Home'])]),
+				v('li', [w(Link, { key: 'about', to: 'about' }, ['About'])]),
+				v('li', [w(Link, { key: 'topics', to: 'topics' }, ['Topics'])])
 			]),
 			w(AboutOutlet, {}),
 			w(HomeOutlet, {}),

--- a/src/examples/main.ts
+++ b/src/examples/main.ts
@@ -10,70 +10,91 @@ import { BasicAppOutlet, BasicAppRouteConfig } from './basic';
 import { UrlParametersAppOutlet, UrlParametersRouteConfig } from './url-parameters';
 import { AmbiguousMatchesOutlet, AmbiguousMatchesRouteConfig } from './ambigious-matches';
 
-const applicationRoutes: RouteConfig[] = [
-	BasicAppRouteConfig,
-	UrlParametersRouteConfig,
-	AmbiguousMatchesRouteConfig
-];
+const applicationRoutes: RouteConfig[] = [BasicAppRouteConfig, UrlParametersRouteConfig, AmbiguousMatchesRouteConfig];
 
 const registry = new Registry();
 const router = registerRouterInjector(applicationRoutes, registry);
 
-const styles = { 'text-decoration': 'none', position: 'relative', display: 'block', 'line-height': '1.8', cursor: 'auto', color: 'inherit' };
+const styles = {
+	'text-decoration': 'none',
+	position: 'relative',
+	display: 'block',
+	'line-height': '1.8',
+	cursor: 'auto',
+	color: 'inherit'
+};
 
 class App extends WidgetBase {
 	render() {
 		return v('div', [
-			v('div', {
-				styles: {
-					'font-size': '13px',
-					background: '#eee',
-					overflow: 'auto',
-					position: 'fixed',
-					height: '100vh',
-					left: '0px',
-					top: '0px',
-					bottom: '0px',
-					width: '250px',
-					display: 'block'
-				}
-			}, [
-				v('div', {
+			v(
+				'div',
+				{
 					styles: {
-						'line-height': '1.8',
-						padding: '10px',
+						'font-size': '13px',
+						background: '#eee',
+						overflow: 'auto',
+						position: 'fixed',
+						height: '100vh',
+						left: '0px',
+						top: '0px',
+						bottom: '0px',
+						width: '250px',
 						display: 'block'
 					}
-				}, [
-					v('div', {
-						styles: {
-							'text-transform': 'uppercase',
-							'font-weight': 'bold',
-							color: 'hsl(0, 0%, 32%)',
-							'margin-top': '20px',
-							display: 'block'
-						}
-					},  [ 'Examples' ]),
-					v('div', {
-						styles: {
-							'padding-left': '10px',
-							display: 'block'
-						}
-					}, [
-						w(Link, { key: 'basic', to: 'basic', styles }, [ 'Basic ']),
-						w(Link, { key: 'url', to: 'url-parameters', styles }, [ 'Url Parameters' ]),
-						w(Link, { key: 'amb', to: 'ambiguous-matches', styles }, [ 'Ambiguous Matches' ])
-					])
-				])
-			]),
-			v('div', { styles: {
-				'margin-left': '250px',
-				display: 'block'
-			} }, [
-				w(BasicAppOutlet, {}),
-				w(UrlParametersAppOutlet, {}),
-				w(AmbiguousMatchesOutlet, {})
-			])
+				},
+				[
+					v(
+						'div',
+						{
+							styles: {
+								'line-height': '1.8',
+								padding: '10px',
+								display: 'block'
+							}
+						},
+						[
+							v(
+								'div',
+								{
+									styles: {
+										'text-transform': 'uppercase',
+										'font-weight': 'bold',
+										color: 'hsl(0, 0%, 32%)',
+										'margin-top': '20px',
+										display: 'block'
+									}
+								},
+								['Examples']
+							),
+							v(
+								'div',
+								{
+									styles: {
+										'padding-left': '10px',
+										display: 'block'
+									}
+								},
+								[
+									w(Link, { key: 'basic', to: 'basic', styles }, ['Basic ']),
+									w(Link, { key: 'url', to: 'url-parameters', styles }, ['Url Parameters']),
+									w(Link, { key: 'amb', to: 'ambiguous-matches', styles }, ['Ambiguous Matches'])
+								]
+							)
+						]
+					)
+				]
+			),
+			v(
+				'div',
+				{
+					styles: {
+						'margin-left': '250px',
+						display: 'block'
+					}
+				},
+				[w(BasicAppOutlet, {}), w(UrlParametersAppOutlet, {}), w(AmbiguousMatchesOutlet, {})]
+			)
 		]);
 	}
 }

--- a/src/examples/url-parameters.ts
+++ b/src/examples/url-parameters.ts
@@ -12,31 +12,23 @@ export interface ChildProperties extends WidgetProperties {
 
 export class Child extends WidgetBase<ChildProperties> {
 	render(): DNode {
-		return v('div', [
-			v('h3', [ `ID: ${this.properties.name || 'this must be about'}` ])
-		]);
+		return v('div', [v('h3', [`ID: ${this.properties.name || 'this must be about'}`])]);
 	}
 }
 
-export const ChildOutlet = Outlet(Child, 'child', ({ params }: MapParamsOptions) => { return { name: params.id }; });
+export const ChildOutlet = Outlet(Child, 'child', ({ params }: MapParamsOptions) => {
+	return { name: params.id };
+});
 
 export class App extends WidgetBase {
 	render(): DNode {
 		return v('div', [
-			v('h2', [ 'Accounts' ]),
+			v('h2', ['Accounts']),
 			v('ul', [
-				v('li', [
-					w(Link, { key: '1', to: 'child', params: { id: 'netflix' } }, [ 'Netflix' ])
-				]),
-				v('li', [
-					w(Link, { key: '2', to: 'child', params: { id: 'zillow-group' } }, [ 'Zillow Group' ])
-				]),
-				v('li', [
-					w(Link, { key: '3', to: 'child', params: { id: 'yahoo' } }, [ 'Yahoo' ])
-				]),
-				v('li', [
-					w(Link, { key: '4', to: 'child', params: { id: 'modus-create' } }, [ 'Modus Create' ])
-				])
+				v('li', [w(Link, { key: '1', to: 'child', params: { id: 'netflix' } }, ['Netflix'])]),
+				v('li', [w(Link, { key: '2', to: 'child', params: { id: 'zillow-group' } }, ['Zillow Group'])]),
+				v('li', [w(Link, { key: '3', to: 'child', params: { id: 'yahoo' } }, ['Yahoo'])]),
+				v('li', [w(Link, { key: '4', to: 'child', params: { id: 'modus-create' } }, ['Modus Create'])])
 			]),
 			w(ChildOutlet, {})
 		]);

--- a/src/history/HashHistory.ts
+++ b/src/history/HashHistory.ts
@@ -31,20 +31,22 @@ export class HashHistory extends HistoryBase implements History {
 		this._current = browserLocation.hash.slice(1);
 		this._browserLocation = browserLocation;
 
-		this.own(on(window, 'hashchange', () => {
-			const path = this.normalizePath(browserLocation.hash);
+		this.own(
+			on(window, 'hashchange', () => {
+				const path = this.normalizePath(browserLocation.hash);
 
-			// Ignore hashchange for the current path. Guards against browsers firing hashchange when the history
-			// manager sets the hash.
-			if (path !== this._current) {
-				this._current = path;
-				this.emit({
-					type: 'change',
-					target: this,
-					value: path
-				});
-			}
-		}));
+				// Ignore hashchange for the current path. Guards against browsers firing hashchange when the history
+				// manager sets the hash.
+				if (path !== this._current) {
+					this._current = path;
+					this.emit({
+						type: 'change',
+						target: this,
+						value: path
+					});
+				}
+			})
+		);
 	}
 
 	public prefix(path: string) {

--- a/src/history/StateHistory.ts
+++ b/src/history/StateHistory.ts
@@ -43,11 +43,9 @@ export class StateHistory extends HistoryBase implements History {
 		const pathStartsWithSlash = /^\//.test(path);
 		if (baseEndsWithSlash && pathStartsWithSlash) {
 			return this._base + path.slice(1);
-		}
-		else if (!baseEndsWithSlash && !pathStartsWithSlash) {
+		} else if (!baseEndsWithSlash && !pathStartsWithSlash) {
 			return `${this._base}/${path}`;
-		}
-		else {
+		} else {
 			return this._base + path;
 		}
 	}
@@ -79,10 +77,10 @@ export class StateHistory extends HistoryBase implements History {
 
 		if (base !== '/') {
 			if (/#/.test(base)) {
-				throw new TypeError('base must not contain \'#\'');
+				throw new TypeError("base must not contain '#'");
 			}
 			if (/\?/.test(base)) {
-				throw new TypeError('base must not contain \'?\'');
+				throw new TypeError("base must not contain '?'");
 			}
 		}
 
@@ -92,21 +90,23 @@ export class StateHistory extends HistoryBase implements History {
 		this._current = stripBase(base, location.pathname + location.search);
 		this._browserHistory = browserHistory;
 
-		this.own(on(window, 'popstate', () => {
-			const path = stripBase(base, location.pathname + location.search);
+		this.own(
+			on(window, 'popstate', () => {
+				const path = stripBase(base, location.pathname + location.search);
 
-			// Ignore popstate for the current path. Guards against browsers firing
-			// popstate on page load, see
-			// <https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onpopstate>.
-			if (path !== this._current) {
-				this._current = path;
-				this.emit({
-					type: 'change',
-					target: this,
-					value: path
-				});
-			}
-		}));
+				// Ignore popstate for the current path. Guards against browsers firing
+				// popstate on page load, see
+				// <https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onpopstate>.
+				if (path !== this._current) {
+					this._current = path;
+					this.emit({
+						type: 'change',
+						target: this,
+						value: path
+					});
+				}
+			})
+		);
 	}
 }
 
@@ -117,8 +117,7 @@ function stripBase(base: string, path: string): string {
 
 	if (path.indexOf(base) === 0) {
 		return ensureLeadingSlash(path.slice(base.length));
-	}
-	else {
+	} else {
 		return '/';
 	}
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -51,7 +51,11 @@ export type Component<W extends WidgetBaseInterface = WidgetBaseInterface> = Con
 /**
  * Outlet component options
  */
-export interface OutletComponents<W extends WidgetBaseInterface, I extends WidgetBaseInterface, E extends WidgetBaseInterface> {
+export interface OutletComponents<
+	W extends WidgetBaseInterface,
+	I extends WidgetBaseInterface,
+	E extends WidgetBaseInterface
+> {
 	main?: Component<W>;
 	index?: Component<I>;
 	error?: Component<E>;
@@ -77,7 +81,11 @@ export interface MapParams {
 /**
  * Outlet properties
  */
-export interface OutletProperties<W extends WidgetBaseInterface = WidgetBaseInterface, I extends WidgetBaseInterface = WidgetBaseInterface, E extends WidgetBaseInterface = WidgetBaseInterface> {
+export interface OutletProperties<
+	W extends WidgetBaseInterface = WidgetBaseInterface,
+	I extends WidgetBaseInterface = WidgetBaseInterface,
+	E extends WidgetBaseInterface = WidgetBaseInterface
+> {
 	outlet: string;
 	mainComponent?: Component<W>;
 	indexComponent?: Component<I>;
@@ -382,6 +390,15 @@ export interface RouteInterface<C extends Context, P extends Parameters> {
 
 	append(add: RouteInterface<Context, Parameters> | RouteInterface<Context, Parameters>[]): void;
 	link(params?: LinkParams): string;
-	match(segments: string[], hasTrailingSlash: boolean, searchParams: UrlSearchParams): null | MatchResult<DefaultParameters | P>;
-	select(context: C, segments: string[], hasTrailingSlash: boolean, searchParams: UrlSearchParams): string | Selection[];
+	match(
+		segments: string[],
+		hasTrailingSlash: boolean,
+		searchParams: UrlSearchParams
+	): null | MatchResult<DefaultParameters | P>;
+	select(
+		context: C,
+		segments: string[],
+		hasTrailingSlash: boolean,
+		searchParams: UrlSearchParams
+	): string | Selection[];
 }

--- a/src/lib/path.ts
+++ b/src/lib/path.ts
@@ -35,14 +35,12 @@ export function parse(path: string): ParsedPath {
 			// Either `/foo?bar#baz` or `/foo#bar?baz`
 			pathnameTokens = tokens.slice(0, Math.min(searchStart, hashStart));
 			searchParams = new UrlSearchParams(tokens.slice(searchStart + 1, hashStart).join(''));
-		}
-		else {
+		} else {
 			// `/foo?bar`
 			pathnameTokens = tokens.slice(0, searchStart);
 			searchParams = new UrlSearchParams(tokens.slice(searchStart + 1).join(''));
 		}
-	}
-	else {
+	} else {
 		searchParams = new UrlSearchParams();
 		if (hashStart >= 0) {
 			// `/foo#bar`
@@ -50,7 +48,7 @@ export function parse(path: string): ParsedPath {
 		}
 	}
 
-	const segments = pathnameTokens.filter(t => t !== '/');
+	const segments = pathnameTokens.filter((t) => t !== '/');
 	const trailingSlash = pathnameTokens[pathnameTokens.length - 1] === '/' && segments.length > 0;
 
 	return {
@@ -103,8 +101,7 @@ export function match({ expectedSegments }: DeconstructedPath, segments: string[
 		const expected = expectedSegments[i];
 		if (isNamedSegment(expected)) {
 			values.push(value);
-		}
-		else if (expected.literal !== value) {
+		} else if (expected.literal !== value) {
 			isMatch = false;
 		}
 	}
@@ -137,7 +134,7 @@ export type Segment = LiteralSegment | NamedSegment;
  * @return true if the segment is a NamedSegment, false otherwise
  */
 export function isNamedSegment(segment: Segment): segment is NamedSegment {
-	return (<NamedSegment> segment).name !== undefined;
+	return (<NamedSegment>segment).name !== undefined;
 }
 
 /**
@@ -200,7 +197,7 @@ export function deconstruct(path: string): DeconstructedPath {
 				}
 				// Reserve : for future use, e.g. including type data in the parameter declaration.
 				if (name === '{' || name === '&' || /:/.test(name)) {
-					throw new TypeError('Parameter name must not contain \'{\', \'&\' or \':\'');
+					throw new TypeError("Parameter name must not contain '{', '&' or ':'");
 				}
 				if (parameters.indexOf(name) !== -1 || searchParameters.indexOf(name) !== -1) {
 					throw new TypeError(`Parameter must have a unique name, got '${name}'`);
@@ -217,8 +214,7 @@ export function deconstruct(path: string): DeconstructedPath {
 						if (separator !== '&') {
 							throw new TypeError(`Search parameter must be followed by '&', got '${separator}'`);
 						}
-					}
-					else if (separator !== '/' && separator !== '?') {
+					} else if (separator !== '/' && separator !== '?') {
 						throw new TypeError(`Parameter must be followed by '/' or '?', got '${separator}'`);
 					}
 				}
@@ -260,12 +256,12 @@ export function deconstruct(path: string): DeconstructedPath {
 
 			case '&':
 				if (!inSearchComponent) {
-					throw new TypeError('Path segment must not contain \'&\'');
+					throw new TypeError("Path segment must not contain '&'");
 				}
 
 				const next = peek();
 				if (next === '&') {
-					throw new TypeError('Expected parameter in search component, got \'&\'');
+					throw new TypeError("Expected parameter in search component, got '&'");
 				}
 
 				break;
@@ -280,10 +276,10 @@ export function deconstruct(path: string): DeconstructedPath {
 	}
 
 	return Object.freeze({
-		expectedSegments: <Segment[]> Object.freeze(expectedSegments),
+		expectedSegments: <Segment[]>Object.freeze(expectedSegments),
 		leadingSlash,
-		parameters: <string[]> Object.freeze(parameters),
-		searchParameters: <string[]> Object.freeze(searchParameters),
+		parameters: <string[]>Object.freeze(parameters),
+		searchParameters: <string[]>Object.freeze(searchParameters),
 		trailingSlash
 	});
 }

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -23,8 +23,7 @@ export function findRouter(route: RouteInterface<Context, Parameters>): RouterIn
 	const router = parentMap.get(route);
 	if (!router) {
 		throw new Error('Cannot generate link for route that is not in the hierarchy');
-	}
-	else {
+	} else {
 		return router;
 	}
 }

--- a/tests/support/util.ts
+++ b/tests/support/util.ts
@@ -6,11 +6,14 @@ export interface Thenable<T> {
 }
 
 export function isEventuallyRejected<T>(promise: Thenable<T>): Thenable<boolean> {
-	return promise.then<any>(function () {
-		throw new Error('unexpected code path');
-	}, function () {
-		return true; // expect rejection
-	});
+	return promise.then<any>(
+		function() {
+			throw new Error('unexpected code path');
+		},
+		function() {
+			return true; // expect rejection
+		}
+	);
 }
 
 export function throwImmediatly() {

--- a/tests/unit/Link.ts
+++ b/tests/unit/Link.ts
@@ -9,16 +9,20 @@ import MemoryHistory from '../../src/history/MemoryHistory';
 
 const registry = new Registry();
 
-const router = registerRouterInjector([
-	{
-		path: 'foo',
-		outlet: 'foo'
-	},
-	{
-		path: 'foo/{foo}',
-		outlet: 'foo2'
-	}
-], registry, { history: new MemoryHistory() });
+const router = registerRouterInjector(
+	[
+		{
+			path: 'foo',
+			outlet: 'foo'
+		},
+		{
+			path: 'foo/{foo}',
+			outlet: 'foo2'
+		}
+	],
+	registry,
+	{ history: new MemoryHistory() }
+);
 let routerSetPathSpy: SinonSpy;
 
 function createMockEvent(isRightClick: boolean = false) {
@@ -32,10 +36,10 @@ function createMockEvent(isRightClick: boolean = false) {
 }
 
 suite('Link', () => {
-	beforeEach(function () {
+	beforeEach(function() {
 		routerSetPathSpy = spy(router, 'setPath');
 	});
-	afterEach(function () {
+	afterEach(function() {
 		routerSetPathSpy.restore();
 	});
 	test('Generate link component for basic outlet', () => {
@@ -122,8 +126,7 @@ suite('Link', () => {
 		try {
 			link.__render__();
 			assert.fail('Should throw an error when the injected router cannot be found with the routerKey');
-		}
-		catch (err) {
+		} catch (err) {
 			// nothing to see here
 		}
 	});

--- a/tests/unit/Outlet.ts
+++ b/tests/unit/Outlet.ts
@@ -32,7 +32,7 @@ class ErrorWidget extends WidgetBase {
 
 class ParamsWidget extends WidgetBase {
 	render() {
-		return v('div', this.properties, [ 'Params' ]);
+		return v('div', this.properties, ['Params']);
 	}
 }
 
@@ -57,7 +57,6 @@ router.start();
 otherRouter.start();
 
 suite('Outlet', () => {
-
 	test('renders main widget given a partial path match', () => {
 		const TestOutlet = Outlet(MainWidget, 'main');
 
@@ -70,11 +69,14 @@ suite('Outlet', () => {
 		});
 	});
 	test('renders index widget given an exact path match', () => {
-		const TestOutlet = Outlet({
-			main: MainWidget,
-			index: IndexWidget,
-			error: ErrorWidget
-		}, 'main');
+		const TestOutlet = Outlet(
+			{
+				main: MainWidget,
+				index: IndexWidget,
+				error: ErrorWidget
+			},
+			'main'
+		);
 
 		return router.dispatch({}, '/main').then(() => {
 			const outlet = new TestOutlet();
@@ -85,10 +87,13 @@ suite('Outlet', () => {
 		});
 	});
 	test('renders main widget given an exact path match and no index component', () => {
-		const TestOutlet = Outlet({
-			main: MainWidget,
-			error: ErrorWidget
-		}, 'main');
+		const TestOutlet = Outlet(
+			{
+				main: MainWidget,
+				error: ErrorWidget
+			},
+			'main'
+		);
 
 		return router.dispatch({}, '/main').then(() => {
 			const outlet = new TestOutlet();
@@ -99,10 +104,13 @@ suite('Outlet', () => {
 		});
 	});
 	test('renders error widget given no path match and no index component', () => {
-		const TestOutlet = Outlet({
-			main: MainWidget,
-			error: ErrorWidget
-		}, 'next');
+		const TestOutlet = Outlet(
+			{
+				main: MainWidget,
+				error: ErrorWidget
+			},
+			'next'
+		);
 
 		return router.dispatch({}, '/main/next/other').then(() => {
 			const outlet = new TestOutlet();
@@ -113,10 +121,13 @@ suite('Outlet', () => {
 		});
 	});
 	test('renders null given a partial path match and no main component', () => {
-		const TestOutlet = Outlet({
-			index: IndexWidget,
-			error: ErrorWidget
-		}, 'main');
+		const TestOutlet = Outlet(
+			{
+				index: IndexWidget,
+				error: ErrorWidget
+			},
+			'main'
+		);
 
 		return router.dispatch({}, '/main/next').then(() => {
 			const outlet = new TestOutlet();
@@ -127,10 +138,13 @@ suite('Outlet', () => {
 		});
 	});
 	test('renders null when null outlet matches', () => {
-		const TestOutlet = Outlet({
-			index: IndexWidget,
-			error: ErrorWidget
-		}, 'main');
+		const TestOutlet = Outlet(
+			{
+				index: IndexWidget,
+				error: ErrorWidget
+			},
+			'main'
+		);
 
 		return router.dispatch({}, '/other').then(() => {
 			const outlet = new TestOutlet();
@@ -140,21 +154,25 @@ suite('Outlet', () => {
 			assert.isNull(dNode);
 		});
 	});
-	test('params get passed to getProperties mapper and the returned object injected into widget as properties',
-		() => {
-			const TestOutlet = Outlet(ParamsWidget, 'params', (options) => {
+	test('params get passed to getProperties mapper and the returned object injected into widget as properties', () => {
+		const TestOutlet = Outlet(
+			ParamsWidget,
+			'params',
+			(options) => {
 				return options;
-			}, 'router-key');
+			},
+			'router-key'
+		);
 
-			return router.dispatch({}, '/main/my-param').then(() => {
-				const outlet = new TestOutlet();
-				outlet.__setCoreProperties__({ bind: outlet, baseRegistry: registry });
-				outlet.__setProperties__({});
-				const dNode: any = outlet.__render__();
-				assert.strictEqual(dNode.properties.router, router);
-				assert.strictEqual(dNode.properties.location, 'main/my-param');
-				assert.deepEqual(dNode.properties.params, { param: 'my-param' });
-				assert.strictEqual(dNode.properties.type, MatchType.INDEX);
-			});
+		return router.dispatch({}, '/main/my-param').then(() => {
+			const outlet = new TestOutlet();
+			outlet.__setCoreProperties__({ bind: outlet, baseRegistry: registry });
+			outlet.__setProperties__({});
+			const dNode: any = outlet.__render__();
+			assert.strictEqual(dNode.properties.router, router);
+			assert.strictEqual(dNode.properties.location, 'main/my-param');
+			assert.deepEqual(dNode.properties.params, { param: 'my-param' });
+			assert.strictEqual(dNode.properties.type, MatchType.INDEX);
 		});
+	});
 });

--- a/tests/unit/Route.ts
+++ b/tests/unit/Route.ts
@@ -17,7 +17,7 @@ suite('Route', () => {
 
 	test('a route is not matched if guard() returns false', () => {
 		const route = new Route({
-			guard () {
+			guard() {
 				return false;
 			}
 		});
@@ -28,9 +28,9 @@ suite('Route', () => {
 
 	test('guard() receives the context', () => {
 		const context: Context = {};
-		let received: Context = <any> undefined;
+		let received: Context = <any>undefined;
 		const route = new Route({
-			guard ({ context }) {
+			guard({ context }) {
 				received = context;
 				return true;
 			}
@@ -41,31 +41,51 @@ suite('Route', () => {
 	});
 
 	test('path must not contain #', () => {
-		assert.throws(() => {
-			new Route({ path: '/foo#' });
-		}, TypeError, 'Path must not contain \'#\'');
+		assert.throws(
+			() => {
+				new Route({ path: '/foo#' });
+			},
+			TypeError,
+			"Path must not contain '#'"
+		);
 	});
 
 	test('path segments cannot contain &', () => {
-		assert.throws(() => {
-			new Route({ path: '/&/bar' });
-		}, TypeError, 'Path segment must not contain \'&\'');
+		assert.throws(
+			() => {
+				new Route({ path: '/&/bar' });
+			},
+			TypeError,
+			"Path segment must not contain '&'"
+		);
 	});
 
 	test('path segments cannot be empty', () => {
-		assert.throws(() => {
-			new Route({ path: '/foo//bar' });
-		}, TypeError, 'Path segment must not be empty');
+		assert.throws(
+			() => {
+				new Route({ path: '/foo//bar' });
+			},
+			TypeError,
+			'Path segment must not be empty'
+		);
 	});
 
 	test('path must contain at least one segment', () => {
-		assert.throws(() => {
-			new Route({ path: '?{query}' });
-		}, TypeError, 'Path must contain at least one segment');
+		assert.throws(
+			() => {
+				new Route({ path: '?{query}' });
+			},
+			TypeError,
+			'Path must contain at least one segment'
+		);
 
-		assert.throws(() => {
-			new Route({ path: '/?{query}' });
-		}, TypeError, 'Path must contain at least one segment');
+		assert.throws(
+			() => {
+				new Route({ path: '/?{query}' });
+			},
+			TypeError,
+			'Path must contain at least one segment'
+		);
 	});
 
 	test('path parameters are extracted', () => {
@@ -73,12 +93,17 @@ suite('Route', () => {
 			path: '/{foo}/{bar}?{baz}&{qux}'
 		});
 
-		const result = route.select({} as Context, ['quux', 'corge'], false, new UrlSearchParams('baz=grault&qux=garply'));
+		const result = route.select(
+			{} as Context,
+			['quux', 'corge'],
+			false,
+			new UrlSearchParams('baz=grault&qux=garply')
+		);
 		if (typeof result === 'string') {
 			throw new TypeError('Unexpected result');
 		}
 
-		const [ { params } ] = result;
+		const [{ params }] = result;
 		assert.deepEqual(params, {
 			foo: 'quux',
 			bar: 'corge',
@@ -97,7 +122,7 @@ suite('Route', () => {
 			throw new TypeError('Unexpected result');
 		}
 
-		const [ { params } ] = result;
+		const [{ params }] = result;
 		assert.deepEqual(params, {
 			foo: 'quux',
 			bar: 'corge',
@@ -110,12 +135,17 @@ suite('Route', () => {
 			path: '/{foo}/{bar}?{baz}&{qux}'
 		});
 
-		const result = route.select({} as Context, ['quux', 'corge'], false, new UrlSearchParams('baz=grault&baz=garply'));
+		const result = route.select(
+			{} as Context,
+			['quux', 'corge'],
+			false,
+			new UrlSearchParams('baz=grault&baz=garply')
+		);
 		if (typeof result === 'string') {
 			throw new TypeError('Unexpected result');
 		}
 
-		const [ { params } ] = result;
+		const [{ params }] = result;
 		assert.deepEqual(params, {
 			foo: 'quux',
 			bar: 'corge',
@@ -124,76 +154,136 @@ suite('Route', () => {
 	});
 
 	test('path parameters cannot contain {, & or :', () => {
-		assert.throws(() => {
-			new Route({ path: '/{{}' });
-		}, TypeError, 'Parameter name must not contain \'{\', \'&\' or \':\'');
+		assert.throws(
+			() => {
+				new Route({ path: '/{{}' });
+			},
+			TypeError,
+			"Parameter name must not contain '{', '&' or ':'"
+		);
 
-		assert.throws(() => {
-			new Route({ path: '/{&}' });
-		}, TypeError, 'Parameter name must not contain \'{\', \'&\' or \':\'');
+		assert.throws(
+			() => {
+				new Route({ path: '/{&}' });
+			},
+			TypeError,
+			"Parameter name must not contain '{', '&' or ':'"
+		);
 
-		assert.throws(() => {
-			new Route({ path: '/{:}' });
-		}, TypeError, 'Parameter name must not contain \'{\', \'&\' or \':\'');
+		assert.throws(
+			() => {
+				new Route({ path: '/{:}' });
+			},
+			TypeError,
+			"Parameter name must not contain '{', '&' or ':'"
+		);
 	});
 
 	test('path parameters must be named', () => {
-		assert.throws(() => {
-			new Route({ path: '/{}/' });
-		}, TypeError, 'Parameter must have a name');
+		assert.throws(
+			() => {
+				new Route({ path: '/{}/' });
+			},
+			TypeError,
+			'Parameter must have a name'
+		);
 	});
 
 	test('path parameters must be closed', () => {
-		assert.throws(() => {
-			new Route({ path: '/{foo/' });
-		}, TypeError, 'Parameter name must be followed by \'}\', got \'/\'');
+		assert.throws(
+			() => {
+				new Route({ path: '/{foo/' });
+			},
+			TypeError,
+			"Parameter name must be followed by '}', got '/'"
+		);
 	});
 
 	test('path parameters must be separated by /', () => {
-		assert.throws(() => {
-			new Route({ path: '/{foo}{bar}' });
-		}, TypeError, 'Parameter must be followed by \'/\' or \'?\', got \'{\'');
+		assert.throws(
+			() => {
+				new Route({ path: '/{foo}{bar}' });
+			},
+			TypeError,
+			"Parameter must be followed by '/' or '?', got '{'"
+		);
 	});
 
 	test('search parameters must be separated by &', () => {
-		assert.throws(() => {
-			new Route({ path: '/segment?{foo}{bar}' });
-		}, TypeError, 'Search parameter must be followed by \'&\', got \'{\'');
+		assert.throws(
+			() => {
+				new Route({ path: '/segment?{foo}{bar}' });
+			},
+			TypeError,
+			"Search parameter must be followed by '&', got '{'"
+		);
 	});
 
 	test('search component must only contain parameters', () => {
-		assert.throws(() => {
-			new Route({ path: '/segment?foo=bar' });
-		}, TypeError, 'Expected parameter in search component, got \'foo=bar\'');
+		assert.throws(
+			() => {
+				new Route({ path: '/segment?foo=bar' });
+			},
+			TypeError,
+			"Expected parameter in search component, got 'foo=bar'"
+		);
 
-		assert.throws(() => {
-			new Route({ path: '/segment?{foo}&/bar' });
-		}, TypeError, 'Expected parameter in search component, got \'/\'');
+		assert.throws(
+			() => {
+				new Route({ path: '/segment?{foo}&/bar' });
+			},
+			TypeError,
+			"Expected parameter in search component, got '/'"
+		);
 
-		assert.throws(() => {
-			new Route({ path: '/segment?{foo}&?bar' });
-		}, TypeError, 'Expected parameter in search component, got \'?\'');
+		assert.throws(
+			() => {
+				new Route({ path: '/segment?{foo}&?bar' });
+			},
+			TypeError,
+			"Expected parameter in search component, got '?'"
+		);
 
-		assert.throws(() => {
-			new Route({ path: '/segment?{foo}&&bar' });
-		}, TypeError, 'Expected parameter in search component, got \'&\'');
+		assert.throws(
+			() => {
+				new Route({ path: '/segment?{foo}&&bar' });
+			},
+			TypeError,
+			"Expected parameter in search component, got '&'"
+		);
 	});
 
 	test('path parameters must have unique names', () => {
-		assert.throws(() => {
-			new Route({ path: '/{foo}/{foo}' });
-		}, TypeError, 'Parameter must have a unique name, got \'foo\'');
+		assert.throws(
+			() => {
+				new Route({ path: '/{foo}/{foo}' });
+			},
+			TypeError,
+			"Parameter must have a unique name, got 'foo'"
+		);
 
-		assert.throws(() => {
-			new Route({ path: '/{foo}?{foo}' });
-		}, TypeError, 'Parameter must have a unique name, got \'foo\'');
-		assert.throws(() => {
-			new Route({ path: '/segment?{foo}&{foo}' });
-		}, TypeError, 'Parameter must have a unique name, got \'foo\'');
+		assert.throws(
+			() => {
+				new Route({ path: '/{foo}?{foo}' });
+			},
+			TypeError,
+			"Parameter must have a unique name, got 'foo'"
+		);
+		assert.throws(
+			() => {
+				new Route({ path: '/segment?{foo}&{foo}' });
+			},
+			TypeError,
+			"Parameter must have a unique name, got 'foo'"
+		);
 
-		assert.throws(() => {
-			new Route({ path: '/segment?{foo}&{foo}' });
-		}, TypeError, 'Parameter must have a unique name, got \'foo\'');
+		assert.throws(
+			() => {
+				new Route({ path: '/segment?{foo}&{foo}' });
+			},
+			TypeError,
+			"Parameter must have a unique name, got 'foo'"
+		);
 	});
 
 	test('deconstructed path can be accessed and is deeply frozen', () => {
@@ -208,22 +298,19 @@ suite('Route', () => {
 		assert.lengthOf(expectedSegments, 2);
 		assert.isTrue(Object.isFrozen(expectedSegments[0]));
 		assert.isTrue(Object.isFrozen(expectedSegments[1]));
-		assert.deepEqual(expectedSegments, [
-			{ literal: 'foo' },
-			{ name: 'bar' }
-		]);
+		assert.deepEqual(expectedSegments, [{ literal: 'foo' }, { name: 'bar' }]);
 
 		assert.isTrue(leadingSlash);
-		assert.deepEqual(parameters, [ 'bar' ]);
-		assert.deepEqual(searchParameters, [ 'baz' ]);
+		assert.deepEqual(parameters, ['bar']);
+		assert.deepEqual(searchParameters, ['baz']);
 		assert.isFalse(trailingSlash);
 	});
 
 	test('guard() receives the extracted parameters', () => {
-		let received: Parameters = <any> undefined;
+		let received: Parameters = <any>undefined;
 		const route = new Route({
 			path: '/{foo}/{bar}?{baz}&{qux}',
-			guard ({ params }) {
+			guard({ params }) {
 				received = params;
 				return true;
 			}
@@ -244,7 +331,7 @@ suite('Route', () => {
 		}
 		const route = new Route<Context, Customized>({
 			path: '/{foo}/{bar}',
-			params (fromPath) {
+			params(fromPath) {
 				const [foo, bar] = fromPath;
 				return {
 					upper: foo.toUpperCase(),
@@ -258,7 +345,7 @@ suite('Route', () => {
 			throw new TypeError('Unexpected result');
 		}
 
-		const [ { params } ] = result;
+		const [{ params }] = result;
 		assert.deepEqual(params, {
 			upper: 'BAZ',
 			barIsQux: true
@@ -272,7 +359,7 @@ suite('Route', () => {
 		}
 		const route = new Route<Context, Customized>({
 			path: '/segment?{foo}&{bar}',
-			params (fromPath, searchParams) {
+			params(fromPath, searchParams) {
 				return {
 					fooArr: searchParams.getAll('foo') || [],
 					barIsQux: searchParams.get('bar') === 'qux'
@@ -285,29 +372,33 @@ suite('Route', () => {
 			throw new TypeError('Unexpected result');
 		}
 
-		const [ { params } ] = result;
+		const [{ params }] = result;
 		assert.deepEqual(params, {
 			fooArr: ['baz', 'BAZ'],
 			barIsQux: true
 		});
 	});
 
-	test('parameter extraction cannot be customized if the path doesn\'t contain parameters', () => {
-		assert.throws(() => {
-			new Route({
-				path: '/foo/bar',
-				params () {
-					return {};
-				}
-			});
-		}, TypeError, 'Can\'t specify params() if path doesn\'t contain any');
+	test("parameter extraction cannot be customized if the path doesn't contain parameters", () => {
+		assert.throws(
+			() => {
+				new Route({
+					path: '/foo/bar',
+					params() {
+						return {};
+					}
+				});
+			},
+			TypeError,
+			"Can't specify params() if path doesn't contain any"
+		);
 	});
 
 	test('parameter extraction can cause a route not to match', () => {
 		const route = new Route({
 			path: '/{foo}',
-			params () {
-				return <any> null;
+			params() {
+				return <any>null;
 			}
 		});
 
@@ -416,7 +507,7 @@ suite('Route', () => {
 	});
 
 	test('if present in route, there must be a trailing slash when selecting', () => {
-		[true, false].forEach(withSlash => {
+		[true, false].forEach((withSlash) => {
 			const root = new Route({ path: '/foo/' });
 			const deep = new Route({ path: '/bar/' });
 			const deeper = new Route({ path: '/baz/' });
@@ -424,12 +515,16 @@ suite('Route', () => {
 			deep.append(deeper);
 
 			const selections = root.select({} as Context, ['foo', 'bar', 'baz'], withSlash, new UrlSearchParams());
-			assert.lengthOf(selections, withSlash ? 3 : 0, `there is ${withSlash ? 'a' : 'no'} trailing slash when selecting`);
+			assert.lengthOf(
+				selections,
+				withSlash ? 3 : 0,
+				`there is ${withSlash ? 'a' : 'no'} trailing slash when selecting`
+			);
 		});
 	});
 
 	test('if not present in route, there must not be a trailing slash when selecting', () => {
-		[true, false].forEach(withSlash => {
+		[true, false].forEach((withSlash) => {
 			const root = new Route({ path: '/foo/' });
 			const deep = new Route({ path: '/bar/' });
 			const deeper = new Route({ path: '/baz' });
@@ -437,12 +532,16 @@ suite('Route', () => {
 			deep.append(deeper);
 
 			const selections = root.select({} as Context, ['foo', 'bar', 'baz'], withSlash, new UrlSearchParams());
-			assert.lengthOf(selections, withSlash ? 0 : 3, `there is ${withSlash ? 'a' : 'no'} trailing slash when selecting`);
+			assert.lengthOf(
+				selections,
+				withSlash ? 0 : 3,
+				`there is ${withSlash ? 'a' : 'no'} trailing slash when selecting`
+			);
 		});
 	});
 
 	test('routes can be configured to ignore trailing slash discrepancies', () => {
-		[true, false].forEach(withSlash => {
+		[true, false].forEach((withSlash) => {
 			const root = new Route({ path: '/foo/' });
 			const deep = new Route({ path: '/bar/' });
 			const deeper = new Route({
@@ -473,10 +572,15 @@ suite('Route', () => {
 		root.append(deep);
 		deep.append(deeper);
 
-		const selections = root.select({} as Context, ['foo', 'root', 'bar', 'deep', 'baz', 'deeper'], false, new UrlSearchParams({
-			'foo': [ 'foo'] ,
-			'baz': [ 'one', 'two' ]
-		}));
+		const selections = root.select(
+			{} as Context,
+			['foo', 'root', 'bar', 'deep', 'baz', 'deeper'],
+			false,
+			new UrlSearchParams({
+				foo: ['foo'],
+				baz: ['one', 'two']
+			})
+		);
 		if (typeof selections === 'string') {
 			throw new TypeError('Unexpected result');
 		}
@@ -484,20 +588,20 @@ suite('Route', () => {
 		assert.lengthOf(selections, 3);
 		const [first, second, third] = selections;
 		assert.deepEqual(first.params, { param: 'root', foo: 'foo' });
-		assert.deepEqual(first.rawPathValues, [ 'root' ]);
-		assert.deepEqual(first.rawSearchParams, { foo: [ 'foo' ] });
+		assert.deepEqual(first.rawPathValues, ['root']);
+		assert.deepEqual(first.rawSearchParams, { foo: ['foo'] });
 		assert.deepEqual(first.path, deconstructPath('/foo/{param}?{foo}'));
 		assert.strictEqual(first.route, root);
 
 		assert.deepEqual(second.params, { param: 'deep' });
-		assert.deepEqual(second.rawPathValues, [ 'deep' ]);
+		assert.deepEqual(second.rawPathValues, ['deep']);
 		assert.deepEqual(second.rawSearchParams, {});
 		assert.deepEqual(second.path, deconstructPath('/bar/{param}?{bar}'));
 		assert.strictEqual(second.route, deep);
 
 		assert.deepEqual(third.params, { param: 'deeper', foo: 'foo', baz: 'one' });
-		assert.deepEqual(third.rawPathValues, [ 'deeper' ]);
-		assert.deepEqual(third.rawSearchParams, { foo: [ 'foo' ], baz: [ 'one', 'two' ] });
+		assert.deepEqual(third.rawPathValues, ['deeper']);
+		assert.deepEqual(third.rawSearchParams, { foo: ['foo'], baz: ['one', 'two'] });
 		assert.deepEqual(third.path, deconstructPath('/baz/{param}?{foo}&{baz}'));
 		assert.strictEqual(third.route, deeper);
 	});
@@ -532,14 +636,14 @@ suite('Route', () => {
 		let called: string[];
 		const root = new Route({
 			path: '/root',
-			guard () {
+			guard() {
 				called.push('root');
 				return true;
 			}
 		});
 		const deep = new Route({
 			path: '/deep',
-			guard () {
+			guard() {
 				called.push('deep');
 				return true;
 			}
@@ -556,7 +660,11 @@ suite('Route', () => {
 
 		called = [];
 		root.select({} as Context, ['root', 'deep', 'deeper'], false, new UrlSearchParams());
-		assert.deepEqual(called, ['root'], '/root/deep/deeper (deep isn’t selected because it doesn’t have a fallback)');
+		assert.deepEqual(
+			called,
+			['root'],
+			'/root/deep/deeper (deep isn’t selected because it doesn’t have a fallback)'
+		);
 	});
 
 	test('can append several routes at once', () => {
@@ -575,15 +683,27 @@ suite('Route', () => {
 		const baz = new Route({ path: '/baz' });
 
 		foo.append(bar);
-		assert.throws(() => {
-			foo.append(bar);
-		}, Error, 'Cannot append route that has already been appended');
-		assert.throws(() => {
-			foo.append([ bar, baz ]);
-		}, Error, 'Cannot append route that has already been appended');
-		assert.throws(() => {
-			baz.append(bar);
-		}, Error, 'Cannot append route that has already been appended');
+		assert.throws(
+			() => {
+				foo.append(bar);
+			},
+			Error,
+			'Cannot append route that has already been appended'
+		);
+		assert.throws(
+			() => {
+				foo.append([bar, baz]);
+			},
+			Error,
+			'Cannot append route that has already been appended'
+		);
+		assert.throws(
+			() => {
+				baz.append(bar);
+			},
+			Error,
+			'Cannot append route that has already been appended'
+		);
 	});
 
 	test('link() throws if the route has not been appended to a router', () => {
@@ -591,12 +711,20 @@ suite('Route', () => {
 		const bar = new Route();
 		foo.append(bar);
 
-		assert.throws(() => {
-			foo.link();
-		}, Error, 'Cannot generate link for route that is not in the hierarchy');
-		assert.throws(() => {
-			bar.link();
-		}, Error, 'Cannot generate link for route that is not in the hierarchy');
+		assert.throws(
+			() => {
+				foo.link();
+			},
+			Error,
+			'Cannot generate link for route that is not in the hierarchy'
+		);
+		assert.throws(
+			() => {
+				bar.link();
+			},
+			Error,
+			'Cannot generate link for route that is not in the hierarchy'
+		);
 	});
 
 	test('link() forwards to link() on router', () => {

--- a/tests/unit/Router.ts
+++ b/tests/unit/Router.ts
@@ -19,7 +19,7 @@ import Router from '../../src/Router';
 
 suite('Router', () => {
 	test('dispatch() resolves to unsuccessful result if no route was executed', () => {
-		return new Router().dispatch({} as Context, '/').then(result => {
+		return new Router().dispatch({} as Context, '/').then((result) => {
 			assert.deepEqual(result, { success: false });
 		});
 	});
@@ -27,7 +27,7 @@ suite('Router', () => {
 	test('dispatch() resolves to successful result if a route was executed', () => {
 		const router = new Router();
 		router.append(new Route());
-		return router.dispatch({} as Context, '/').then(result => {
+		return router.dispatch({} as Context, '/').then((result) => {
 			assert.deepEqual(result, { success: true });
 		});
 	});
@@ -35,24 +35,33 @@ suite('Router', () => {
 	test('dispatch() rejects when errors occur', () => {
 		const err = {};
 		const router = new Router();
-		router.append(new Route({
-			exec () {
-				throw err;
+		router.append(
+			new Route({
+				exec() {
+					throw err;
+				}
+			})
+		);
+		return router.dispatch({} as Context, '/').then(
+			() => {
+				assert.fail('Should not be called');
+			},
+			(actual) => {
+				assert.strictEqual(actual, err);
 			}
-		}));
-		return router.dispatch({} as Context, '/').then(() => {
-			assert.fail('Should not be called');
-		}, actual => {
-			assert.strictEqual(actual, err);
-		});
+		);
 	});
 
 	test('dispatch() returns redirect', () => {
 		const router = new Router();
-		router.append(new Route({
-			path: '/foo',
-			guard() { return '/bar'; }
-		}));
+		router.append(
+			new Route({
+				path: '/foo',
+				guard() {
+					return '/bar';
+				}
+			})
+		);
 
 		return router.dispatch({} as Context, '/foo').then((result) => {
 			assert.deepEqual(result, { redirect: '/bar', success: true });
@@ -61,10 +70,14 @@ suite('Router', () => {
 
 	test('dispatch() may return empty redirect', () => {
 		const router = new Router();
-		router.append(new Route({
-			path: '/foo',
-			guard() { return ''; }
-		}));
+		router.append(
+			new Route({
+				path: '/foo',
+				guard() {
+					return '';
+				}
+			})
+		);
 
 		return router.dispatch({} as Context, '/foo').then((result) => {
 			assert.deepEqual(result, { redirect: '', success: true });
@@ -73,16 +86,24 @@ suite('Router', () => {
 
 	test('dispatch() stops selecting routes once it has a redirect', () => {
 		const router = new Router();
-		router.append(new Route({
-			path: '/foo',
-			guard() { return '/bar'; }
-		}));
+		router.append(
+			new Route({
+				path: '/foo',
+				guard() {
+					return '/bar';
+				}
+			})
+		);
 
 		let executed = false;
-		router.append(new Route({
-			path: '/foo',
-			exec() { executed = true; }
-		}));
+		router.append(
+			new Route({
+				path: '/foo',
+				exec() {
+					executed = true;
+				}
+			})
+		);
 
 		return router.dispatch({} as Context, '/foo').then((result) => {
 			assert.deepEqual(result, { redirect: '/bar', success: true });
@@ -91,19 +112,19 @@ suite('Router', () => {
 	});
 
 	test('dispatch() executes selected routes, providing context and extracted parameters', () => {
-		const execs: { context: Context, params: Parameters }[] = [];
+		const execs: { context: Context; params: Parameters }[] = [];
 
 		const context = {} as Context;
 		const router = new Router();
 		const root = new Route({
 			path: '/{foo}',
-			exec ({ context, params }) {
+			exec({ context, params }) {
 				execs.push({ context, params });
 			}
 		});
 		const deep = new Route({
 			path: '/{bar}',
-			exec ({ context, params }) {
+			exec({ context, params }) {
 				execs.push({ context, params });
 			}
 		});
@@ -120,22 +141,22 @@ suite('Router', () => {
 	});
 
 	test('dispatch() calls index() on the final selected route, providing context and extracted parameters', () => {
-		const calls: { method: string, context: Context, params: Parameters }[] = [];
+		const calls: { method: string; context: Context; params: Parameters }[] = [];
 
 		const context = {} as Context;
 		const router = new Router();
 		const root = new Route({
 			path: '/{foo}',
-			exec ({ context, params }) {
+			exec({ context, params }) {
 				calls.push({ method: 'exec', context, params });
 			}
 		});
 		const deep = new Route({
 			path: '/{bar}',
-			exec ({ context, params }) {
+			exec({ context, params }) {
 				calls.push({ method: 'exec', context, params });
 			},
-			index ({ context, params }) {
+			index({ context, params }) {
 				calls.push({ method: 'index', context, params });
 			}
 		});
@@ -154,16 +175,16 @@ suite('Router', () => {
 	});
 
 	test('dispatch() calls fallback() on the deepest matching route, providing context and extracted parameters', () => {
-		const calls: { method: string, context: Context, params: Parameters }[] = [];
+		const calls: { method: string; context: Context; params: Parameters }[] = [];
 
 		const context = {} as Context;
 		const router = new Router();
 		const root = new Route({
 			path: '/{foo}',
-			exec ({ context, params }) {
+			exec({ context, params }) {
 				calls.push({ method: 'exec', context, params });
 			},
-			fallback ({ context, params }) {
+			fallback({ context, params }) {
 				calls.push({ method: 'fallback', context, params });
 			}
 		});
@@ -181,19 +202,23 @@ suite('Router', () => {
 		const order: string[] = [];
 
 		const router = new Router();
-		router.append(new Route({
-			path: '/foo',
-			guard () {
-				order.push('first');
-				return false;
-			}
-		}));
-		router.append(new Route({
-			path: '/foo',
-			exec () {
-				order.push('second');
-			}
-		}));
+		router.append(
+			new Route({
+				path: '/foo',
+				guard() {
+					order.push('first');
+					return false;
+				}
+			})
+		);
+		router.append(
+			new Route({
+				path: '/foo',
+				exec() {
+					order.push('second');
+				}
+			})
+		);
 
 		return router.dispatch({} as Context, '/foo').then(() => {
 			assert.deepEqual(order, ['first', 'second']);
@@ -204,7 +229,7 @@ suite('Router', () => {
 		const router = new Router<any>();
 
 		let received: NavigationStartEvent = null!;
-		router.on('navstart', event => {
+		router.on('navstart', (event) => {
 			received = event;
 		});
 
@@ -216,7 +241,7 @@ suite('Router', () => {
 	test('navstart listeners can synchronously cancel routing before dispatch', () => {
 		const router = new Router();
 		router.append(new Route({ path: '/foo' }));
-		router.on('navstart', event => {
+		router.on('navstart', (event) => {
 			event.cancel && event.cancel();
 		});
 
@@ -230,7 +255,7 @@ suite('Router', () => {
 		let cancel: Function | undefined = undefined;
 		const router = new Router();
 		router.append(new Route({ path: '/foo' }));
-		router.on('navstart', event => {
+		router.on('navstart', (event) => {
 			if (event.cancel) {
 				cancel = event.cancel;
 			}
@@ -248,7 +273,7 @@ suite('Router', () => {
 	test('navstart listeners can asynchronously cancel routing', () => {
 		const router = new Router();
 		router.append(new Route({ path: '/foo' }));
-		router.on('navstart', event => {
+		router.on('navstart', (event) => {
 			if (event.defer) {
 				const { cancel } = event.defer();
 				Promise.resolve().then(cancel);
@@ -264,7 +289,7 @@ suite('Router', () => {
 	test('navstart listeners can asynchronously resume routing', () => {
 		const router = new Router();
 		router.append(new Route({ path: '/foo' }));
-		router.on('navstart', event => {
+		router.on('navstart', (event) => {
 			if (event.defer) {
 				const { resume } = event.defer();
 				Promise.resolve().then(resume);
@@ -281,14 +306,14 @@ suite('Router', () => {
 		const router = new Router();
 		router.append(new Route({ path: '/foo' }));
 
-		const resumers: {(): void}[] = [];
-		router.on('navstart', event => {
+		const resumers: { (): void }[] = [];
+		router.on('navstart', (event) => {
 			if (event.defer) {
 				const { resume } = event.defer();
 				resumers.push(resume);
 			}
 		});
-		router.on('navstart', event => {
+		router.on('navstart', (event) => {
 			if (event.defer) {
 				const { resume } = event.defer();
 				resumers.push(resume);
@@ -301,31 +326,38 @@ suite('Router', () => {
 			dispatched = success;
 		});
 
-		const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+		const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-		return Promise.resolve().then(() => {
-			assert.isFalse(dispatched);
-			(<any> resumers.shift())();
-			return delay(10);
-		}).then(() => {
-			assert.isFalse(dispatched);
-			(<any> resumers.shift())();
-			return delay(10);
-		}).then(() => {
-			assert.isTrue(dispatched);
-		});
+		return Promise.resolve()
+			.then(() => {
+				assert.isFalse(dispatched);
+				(<any>resumers.shift())();
+				return delay(10);
+			})
+			.then(() => {
+				assert.isFalse(dispatched);
+				(<any>resumers.shift())();
+				return delay(10);
+			})
+			.then(() => {
+				assert.isTrue(dispatched);
+			});
 	});
 
 	test('dispatch() can be canceled', () => {
 		const router = new Router();
 
 		let executed = false;
-		router.append(new Route({
-			path: '/foo',
-			exec () { executed = true; }
-		}));
+		router.append(
+			new Route({
+				path: '/foo',
+				exec() {
+					executed = true;
+				}
+			})
+		);
 
-		router.on('navstart', event => {
+		router.on('navstart', (event) => {
 			const task = new Router().dispatch({} as Context, '/foo');
 			task.cancel();
 			if (event.defer) {
@@ -333,7 +365,7 @@ suite('Router', () => {
 			}
 		});
 
-		return new Promise(resolve => setTimeout(resolve, 10)).then(() => {
+		return new Promise((resolve) => setTimeout(resolve, 10)).then(() => {
 			assert.isFalse(executed);
 		});
 	});
@@ -353,7 +385,6 @@ suite('Router', () => {
 						]
 					}
 				]
-
 			}
 		];
 
@@ -381,7 +412,6 @@ suite('Router', () => {
 						]
 					}
 				]
-
 			}
 		];
 
@@ -412,7 +442,6 @@ suite('Router', () => {
 						]
 					}
 				]
-
 			}
 		];
 
@@ -463,7 +492,6 @@ suite('Router', () => {
 						]
 					}
 				]
-
 			}
 		];
 
@@ -504,28 +532,38 @@ suite('Router', () => {
 	});
 
 	test('query for multiple outlets', async () => {
-		const config = [{
-			path: '/path-1',
-			outlet: 'outlet-id-1'
-		}, {
-			path: '/path-2',
-			outlet: 'outlet-id-2',
-			children: [{
-				path: '/nested-path',
-				outlet: 'outlet-id-3',
-				children: [{
-					path: '/nested-path',
-					outlet: 'outlet-id-4',
-					children: [{
+		const config = [
+			{
+				path: '/path-1',
+				outlet: 'outlet-id-1'
+			},
+			{
+				path: '/path-2',
+				outlet: 'outlet-id-2',
+				children: [
+					{
 						path: '/nested-path',
-						outlet: 'outlet-id-5'
-					}]
-				}]
-			}]
-		}, {
-			path: '/path-3',
-			outlet: 'outlet-id-5'
-		}];
+						outlet: 'outlet-id-3',
+						children: [
+							{
+								path: '/nested-path',
+								outlet: 'outlet-id-4',
+								children: [
+									{
+										path: '/nested-path',
+										outlet: 'outlet-id-5'
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			{
+				path: '/path-3',
+				outlet: 'outlet-id-5'
+			}
+		];
 
 		const router = new Router({ config });
 
@@ -572,22 +610,30 @@ suite('Router', () => {
 	});
 
 	test('parameters are combined with multiple matching outlets', async () => {
-		const config = [{
-			path: '/path',
-			outlet: 'outlet-id-1',
-			children: [{
-				path: '/nested-path/{outlet-2-param}',
-				outlet: 'outlet-id-2',
-				children: [{
-					path: '/nested-path/{outlet-3-param}',
-					outlet: 'outlet-id-3',
-					children: [{
-						path: '/nested-path/{outlet-4-param}',
-						outlet: 'outlet-id-4'
-					}]
-				}]
-			}]
-		}];
+		const config = [
+			{
+				path: '/path',
+				outlet: 'outlet-id-1',
+				children: [
+					{
+						path: '/nested-path/{outlet-2-param}',
+						outlet: 'outlet-id-2',
+						children: [
+							{
+								path: '/nested-path/{outlet-3-param}',
+								outlet: 'outlet-id-3',
+								children: [
+									{
+										path: '/nested-path/{outlet-4-param}',
+										outlet: 'outlet-id-4'
+									}
+								]
+							}
+						]
+					}
+				]
+			}
+		];
 
 		const router = new Router({ config });
 
@@ -618,8 +664,7 @@ suite('Router', () => {
 		try {
 			new Router({ config });
 			assert.fail('Should throw an error if multiple default routes are configured.');
-		}
-		catch (err) {
+		} catch (err) {
 			// do nothing expected error
 		}
 	});
@@ -628,7 +673,7 @@ suite('Router', () => {
 		let received: Request<Context, Parameters>;
 
 		const router = new Router({
-			fallback (request) {
+			fallback(request) {
 				received = request;
 			}
 		});
@@ -650,14 +695,14 @@ suite('Router', () => {
 		router.append([
 			new Route({
 				path: '/foo',
-				guard () {
+				guard() {
 					order.push('first');
 					return false;
 				}
 			}),
 			new Route({
 				path: '/foo',
-				exec () {
+				exec() {
 					order.push('second');
 				}
 			})
@@ -675,22 +720,38 @@ suite('Router', () => {
 		const baz = new Route({ path: '/baz' });
 
 		router.append(foo);
-		assert.throws(() => {
-			router.append(foo);
-		}, Error, 'Cannot append route that has already been appended');
-		assert.throws(() => {
-			router.append([ foo, bar ]);
-		}, Error, 'Cannot append route that has already been appended');
+		assert.throws(
+			() => {
+				router.append(foo);
+			},
+			Error,
+			'Cannot append route that has already been appended'
+		);
+		assert.throws(
+			() => {
+				router.append([foo, bar]);
+			},
+			Error,
+			'Cannot append route that has already been appended'
+		);
 
 		foo.append(bar);
-		assert.throws(() => {
-			router.append(bar);
-		}, Error, 'Cannot append route that has already been appended');
+		assert.throws(
+			() => {
+				router.append(bar);
+			},
+			Error,
+			'Cannot append route that has already been appended'
+		);
 
 		router.append(baz);
-		assert.throws(() => {
-			router.append(baz);
-		}, Error, 'Cannot append route that has already been appended');
+		assert.throws(
+			() => {
+				router.append(baz);
+			},
+			Error,
+			'Cannot append route that has already been appended'
+		);
 	});
 
 	test('leading slashes are irrelevant', () => {
@@ -709,57 +770,63 @@ suite('Router', () => {
 	});
 
 	test('if present in route, there must be a trailing slash when selecting', () => {
-		return Promise.all([true, false].map(withSlash => {
-			const router = new Router();
-			const root = new Route({ path: '/foo/' });
-			const deep = new Route({ path: '/bar/' });
-			const deeper = new Route({ path: '/baz/' });
-			root.append(deep);
-			deep.append(deeper);
-			router.append(root);
+		return Promise.all(
+			[true, false].map((withSlash) => {
+				const router = new Router();
+				const root = new Route({ path: '/foo/' });
+				const deep = new Route({ path: '/bar/' });
+				const deeper = new Route({ path: '/baz/' });
+				root.append(deep);
+				deep.append(deeper);
+				router.append(root);
 
-			return router.dispatch({} as Context, `foo/bar/baz${withSlash ? '/' : ''}`).then((dispatchResult) => {
-				const { success } = dispatchResult || { success: false };
-				assert.isTrue(success === withSlash, `there is ${withSlash ? 'a' : 'no'} trailing slash`);
-			});
-		}));
+				return router.dispatch({} as Context, `foo/bar/baz${withSlash ? '/' : ''}`).then((dispatchResult) => {
+					const { success } = dispatchResult || { success: false };
+					assert.isTrue(success === withSlash, `there is ${withSlash ? 'a' : 'no'} trailing slash`);
+				});
+			})
+		);
 	});
 
 	test('if not present in route, there must not be a trailing slash when selecting', () => {
-		return Promise.all([true, false].map(withSlash => {
-			const router = new Router();
-			const root = new Route({ path: '/foo/' });
-			const deep = new Route({ path: '/bar/' });
-			const deeper = new Route({ path: '/baz' });
-			root.append(deep);
-			deep.append(deeper);
-			router.append(root);
+		return Promise.all(
+			[true, false].map((withSlash) => {
+				const router = new Router();
+				const root = new Route({ path: '/foo/' });
+				const deep = new Route({ path: '/bar/' });
+				const deeper = new Route({ path: '/baz' });
+				root.append(deep);
+				deep.append(deeper);
+				router.append(root);
 
-			return router.dispatch({} as Context, `foo/bar/baz${withSlash ? '/' : ''}`).then((dispatchResult) => {
-				const { success } = dispatchResult || { success: false };
-				assert.isTrue(success !== withSlash, `there is ${withSlash ? 'a' : 'no'} trailing slash`);
-			});
-		}));
+				return router.dispatch({} as Context, `foo/bar/baz${withSlash ? '/' : ''}`).then((dispatchResult) => {
+					const { success } = dispatchResult || { success: false };
+					assert.isTrue(success !== withSlash, `there is ${withSlash ? 'a' : 'no'} trailing slash`);
+				});
+			})
+		);
 	});
 
 	test('routes can be configured to ignore trailing slash discrepancies', () => {
-		return Promise.all([true, false].map(withSlash => {
-			const router = new Router();
-			const root = new Route({ path: '/foo/' });
-			const deep = new Route({ path: '/bar/' });
-			const deeper = new Route({
-				path: `/baz${withSlash ? '' : '/'}`,
-				trailingSlashMustMatch: false
-			});
-			root.append(deep);
-			deep.append(deeper);
-			router.append(root);
+		return Promise.all(
+			[true, false].map((withSlash) => {
+				const router = new Router();
+				const root = new Route({ path: '/foo/' });
+				const deep = new Route({ path: '/bar/' });
+				const deeper = new Route({
+					path: `/baz${withSlash ? '' : '/'}`,
+					trailingSlashMustMatch: false
+				});
+				root.append(deep);
+				deep.append(deeper);
+				router.append(root);
 
-			return router.dispatch({} as Context, `foo/bar/baz${withSlash ? '/' : ''}`).then((dispatchResult) => {
-				const { success } = dispatchResult || { success: false };
-				assert.isTrue(success, `there is ${withSlash ? 'a' : 'no'} trailing slash`);
-			});
-		}));
+				return router.dispatch({} as Context, `foo/bar/baz${withSlash ? '/' : ''}`).then((dispatchResult) => {
+					const { success } = dispatchResult || { success: false };
+					assert.isTrue(success, `there is ${withSlash ? 'a' : 'no'} trailing slash`);
+				});
+			})
+		);
 	});
 
 	test('search components are ignored', () => {
@@ -786,15 +853,18 @@ suite('Router', () => {
 		const router = new Router();
 		router.append(new Route({ path: '/foo' }));
 
-		return router.dispatch({} as Context, '/foo?bar#baz').then((dispatchResult) => {
-			const { success } = dispatchResult || { success: false };
-			assert.isTrue(success, '/foo?bar#baz');
+		return router
+			.dispatch({} as Context, '/foo?bar#baz')
+			.then((dispatchResult) => {
+				const { success } = dispatchResult || { success: false };
+				assert.isTrue(success, '/foo?bar#baz');
 
-			return router.dispatch({} as Context, '/foo#bar?baz');
-		}).then((dispatchResult) => {
-			const { success } = dispatchResult || { success: false };
-			assert.isTrue(success);
-		});
+				return router.dispatch({} as Context, '/foo#bar?baz');
+			})
+			.then((dispatchResult) => {
+				const { success } = dispatchResult || { success: false };
+				assert.isTrue(success);
+			});
 	});
 
 	test('repeated slashes have no effect', () => {
@@ -811,33 +881,43 @@ suite('Router', () => {
 		const router = new Router();
 
 		let extracted: DefaultParameters = {};
-		router.append(new Route({
-			path: '/foo?{bar}&{baz}',
-			exec ({ params }) {
-				extracted = <DefaultParameters> params;
-			}
-		}));
+		router.append(
+			new Route({
+				path: '/foo?{bar}&{baz}',
+				exec({ params }) {
+					extracted = <DefaultParameters>params;
+				}
+			})
+		);
 
-		return router.dispatch({} as Context, '/foo?bar=1&baz=2').then(() => {
-			assert.deepEqual(extracted, {bar: '1', baz: '2'});
+		return router
+			.dispatch({} as Context, '/foo?bar=1&baz=2')
+			.then(() => {
+				assert.deepEqual(extracted, { bar: '1', baz: '2' });
 
-			extracted = {};
-			return router.dispatch({} as Context, '/foo?bar=3#baz=4');
-		}).then(() => {
-			assert.deepEqual(extracted, {bar: '3'});
+				extracted = {};
+				return router.dispatch({} as Context, '/foo?bar=3#baz=4');
+			})
+			.then(() => {
+				assert.deepEqual(extracted, { bar: '3' });
 
-			extracted = {};
-			return router.dispatch({} as Context, '/foo#bar=5?baz=6');
-		}).then(() => {
-			assert.deepEqual(extracted, {});
-		});
+				extracted = {};
+				return router.dispatch({} as Context, '/foo#bar=5?baz=6');
+			})
+			.then(() => {
+				assert.deepEqual(extracted, {});
+			});
 	});
 
 	test('replacePath() throws if the router was created without a history manager', () => {
 		const router = new Router();
-		assert.throws(() => {
-			router.replacePath('/foo');
-		}, Error, 'Cannot replace path, router was created without a history manager');
+		assert.throws(
+			() => {
+				router.replacePath('/foo');
+			},
+			Error,
+			'Cannot replace path, router was created without a history manager'
+		);
 	});
 
 	test('replacePath() sets the path on the history manager', () => {
@@ -846,14 +926,18 @@ suite('Router', () => {
 		const router = new Router({ history });
 		router.replacePath('/foo');
 		assert.isTrue(replace.calledOnce);
-		assert.deepEqual(replace.firstCall.args, [ '/foo' ]);
+		assert.deepEqual(replace.firstCall.args, ['/foo']);
 	});
 
 	test('setPath() throws if the router was created without a history manager', () => {
 		const router = new Router();
-		assert.throws(() => {
-			router.setPath('/foo');
-		}, Error, 'Cannot set path, router was created without a history manager');
+		assert.throws(
+			() => {
+				router.setPath('/foo');
+			},
+			Error,
+			'Cannot set path, router was created without a history manager'
+		);
 	});
 
 	test('setPath() sets the path on the history manager', () => {
@@ -862,7 +946,7 @@ suite('Router', () => {
 		const router = new Router({ history });
 		router.setPath('/foo');
 		assert.isTrue(set.calledOnce);
-		assert.deepEqual(set.firstCall.args, [ '/foo' ]);
+		assert.deepEqual(set.firstCall.args, ['/foo']);
 	});
 
 	test('start() is a noop if the router was created without a history manager', () => {
@@ -925,7 +1009,7 @@ suite('Router', () => {
 		});
 
 		router.start({ dispatchCurrent: true });
-		assert.deepEqual(dispatchedPaths, [ '/foo', 'bar' ]);
+		assert.deepEqual(dispatchedPaths, ['/foo', 'bar']);
 	});
 
 	test('start() can be configured not to immediately dispatch for the current history value', () => {
@@ -969,39 +1053,49 @@ suite('Router', () => {
 		router.append([
 			new Route({
 				path: '/foo',
-				guard() { return '/bar'; }
+				guard() {
+					return '/bar';
+				}
 			}),
 			new Route({
 				path: '/bar',
-				exec() { execs.push('/bar'); }
+				exec() {
+					execs.push('/bar');
+				}
 			}),
 			new Route({
 				path: '/baz',
-				guard() { return ''; }
+				guard() {
+					return '';
+				}
 			}),
 			new Route({
 				path: '/',
-				exec() { execs.push('/'); }
+				exec() {
+					execs.push('/');
+				}
 			})
 		]);
 
 		const paths: string[] = [];
-		router.on('navstart', ({ path }) => { paths.push(path); });
+		router.on('navstart', ({ path }) => {
+			paths.push(path);
+		});
 
 		router.start();
 		return new Promise((resolve) => setTimeout(resolve, 50))
 			.then(() => {
 				assert.strictEqual(history.current, '/bar');
-				assert.deepEqual(paths, [ '/foo', '/bar' ]);
-				assert.deepEqual(execs, [ '/bar' ]);
+				assert.deepEqual(paths, ['/foo', '/bar']);
+				assert.deepEqual(execs, ['/bar']);
 
 				history.set('/baz');
 				return new Promise((resolve) => setTimeout(resolve, 50));
 			})
 			.then(() => {
 				assert.strictEqual(history.current, '');
-				assert.deepEqual(paths, [ '/foo', '/bar', '/baz', '' ]);
-				assert.deepEqual(execs, [ '/bar', '/' ]);
+				assert.deepEqual(paths, ['/foo', '/bar', '/baz', '']);
+				assert.deepEqual(execs, ['/bar', '/']);
 			});
 	});
 
@@ -1038,16 +1132,18 @@ suite('Router', () => {
 		return new Promise((resolve) => {
 			ok = resolve;
 			history.set('/to');
-		}).then(() => {
-			assert.equal(count, 20);
-			count = 0;
-			return new Promise((resolve) => {
-				ok = resolve;
-				history.set(history.current === '/to' ? '/and/fro' : '/to');
+		})
+			.then(() => {
+				assert.equal(count, 20);
+				count = 0;
+				return new Promise((resolve) => {
+					ok = resolve;
+					history.set(history.current === '/to' ? '/and/fro' : '/to');
+				});
+			})
+			.then(() => {
+				assert.equal(count, 20);
 			});
-		}).then(() => {
-			assert.equal(count, 20);
-		});
 	});
 
 	test('without a provided context, start() dispatches with an empty object as the context', () => {
@@ -1083,8 +1179,8 @@ suite('Router', () => {
 		assert.strictEqual(contexts[1], context);
 	});
 
-	test('with a provided context factory, start() dispatches with factory\'s value as the context', () => {
-		const expectedContexts = [ { first: true }, { second: true } ];
+	test("with a provided context factory, start() dispatches with factory's value as the context", () => {
+		const expectedContexts = [{ first: true }, { second: true }];
 		const context = () => expectedContexts.shift();
 		const history = new MemoryHistory({ path: '/foo' });
 		const router = new Router({ context, history });
@@ -1102,29 +1198,41 @@ suite('Router', () => {
 
 	test('link() throws if route has not been appended', () => {
 		const router = new Router();
-		assert.throws(() => {
-			router.link(new Route({ path: '/' }));
-		}, Error, 'Cannot generate link for route that is not in the hierarchy');
-		assert.throws(() => {
-			const foo = new Route({ path: '/foo' });
-			const bar = new Route({ path: '/bar' });
-			foo.append(bar);
-			router.link(bar);
-		}, Error, 'Cannot generate link for route that is not in the hierarchy');
-		assert.throws(() => {
-			const foo = new Route({ path: '/foo' });
-			new Router().append(foo);
-			router.link(foo);
-		}, Error, 'Cannot generate link for route that is not in the hierarchy');
+		assert.throws(
+			() => {
+				router.link(new Route({ path: '/' }));
+			},
+			Error,
+			'Cannot generate link for route that is not in the hierarchy'
+		);
+		assert.throws(
+			() => {
+				const foo = new Route({ path: '/foo' });
+				const bar = new Route({ path: '/bar' });
+				foo.append(bar);
+				router.link(bar);
+			},
+			Error,
+			'Cannot generate link for route that is not in the hierarchy'
+		);
+		assert.throws(
+			() => {
+				const foo = new Route({ path: '/foo' });
+				new Router().append(foo);
+				router.link(foo);
+			},
+			Error,
+			'Cannot generate link for route that is not in the hierarchy'
+		);
 	});
 
 	test('link() combines paths of route hierarchy (no parameters)', () => {
 		const router = new Router();
-		const routes = [ 'foo/', '/bar', 'baz/' ].map(path => new Route({ path }));
+		const routes = ['foo/', '/bar', 'baz/'].map((path) => new Route({ path }));
 		routes.reduce<{ append(route: Route<Context, Parameters>): void }>((parent, route) => {
-				parent.append(route);
-				return route;
-			}, router);
+			parent.append(route);
+			return route;
+		}, router);
 
 		assert.equal(router.link(routes[2]), 'foo/bar/baz/');
 		assert.equal(router.link(routes[1]), 'foo/bar');
@@ -1145,12 +1253,20 @@ suite('Router', () => {
 		const route = new Route({ path: '/{foo}?{bar}' });
 		router.append(route);
 
-		assert.throws(() => {
-			router.link(route);
-		}, Error, 'Cannot generate link, missing parameter \'foo\'');
-		assert.throws(() => {
-			router.link(route, { foo: 'foo' });
-		}, Error, 'Cannot generate link, missing search parameter \'bar\'');
+		assert.throws(
+			() => {
+				router.link(route);
+			},
+			Error,
+			"Cannot generate link, missing parameter 'foo'"
+		);
+		assert.throws(
+			() => {
+				router.link(route, { foo: 'foo' });
+			},
+			Error,
+			"Cannot generate link, missing search parameter 'bar'"
+		);
 	});
 
 	test('link() throws if more than one value is provided for a path parameter', () => {
@@ -1158,38 +1274,45 @@ suite('Router', () => {
 		const route = new Route({ path: '/{foo}' });
 		router.append(route);
 
-		assert.equal(router.link(route, { foo: [ 'foo' ] }), '/foo');
-		assert.throws(() => {
-			router.link(route, { foo: [ 'foo', 'bar' ] });
-		}, Error, 'Cannot generate link, multiple values for parameter \'foo\'');
+		assert.equal(router.link(route, { foo: ['foo'] }), '/foo');
+		assert.throws(
+			() => {
+				router.link(route, { foo: ['foo', 'bar'] });
+			},
+			Error,
+			"Cannot generate link, multiple values for parameter 'foo'"
+		);
 	});
 
 	test('link() fills in parameters', () => {
 		const router = new Router();
-		const routes = [ '{foo}', '{foo}?{bar}', 'end?{bar}&{baz}&{foo}' ].map(path => new Route({ path }));
+		const routes = ['{foo}', '{foo}?{bar}', 'end?{bar}&{baz}&{foo}'].map((path) => new Route({ path }));
 		routes.reduce<{ append(route: Route<Context, Parameters>): void }>((parent, route) => {
-				parent.append(route);
-				return route;
-			}, router);
+			parent.append(route);
+			return route;
+		}, router);
 
-		assert.equal(router.link(routes[2], {
-			foo: 'foo',
-			bar: 'bar',
-			baz: [ 'baz1', 'baz2' ]
-		}), 'foo/foo/end?bar=bar&baz=baz1&baz=baz2&foo=foo');
+		assert.equal(
+			router.link(routes[2], {
+				foo: 'foo',
+				bar: 'bar',
+				baz: ['baz1', 'baz2']
+			}),
+			'foo/foo/end?bar=bar&baz=baz1&baz=baz2&foo=foo'
+		);
 	});
 
 	test('link() fills in parameters from currently selected, matching routes', () => {
 		const history = new MemoryHistory();
 		const router = new Router({ history });
-		const routes = [ '/root/{foo}/deeper/{bar}', '{foo}?{bar}' ].map(path => new Route({ path }));
+		const routes = ['/root/{foo}/deeper/{bar}', '{foo}?{bar}'].map((path) => new Route({ path }));
 		const ready = new Promise((resolve) => {
 			routes.push(new Route({ path: 'end?{bar}&{baz}&{foo}', exec: resolve }));
 		});
 		routes.reduce<{ append(route: Route<Context, Parameters>): void }>((parent, route) => {
-				parent.append(route);
-				return route;
-			}, router);
+			parent.append(route);
+			return route;
+		}, router);
 
 		router.start({ dispatchCurrent: false });
 		history.set('/root/FOO/deeper/BAR/foo/end?bar=bar&baz=baz1&baz=baz2&foo=f00');
@@ -1206,20 +1329,23 @@ suite('Router', () => {
 	test('link() lets you override parameters from currently selected, matching routes', () => {
 		const history = new MemoryHistory();
 		const router = new Router({ history });
-		const routes = [ '/root/{foo}/deeper/{bar}', '{foo}?{bar}' ].map(path => new Route({ path }));
+		const routes = ['/root/{foo}/deeper/{bar}', '{foo}?{bar}'].map((path) => new Route({ path }));
 		const ready = new Promise((resolve) => {
 			routes.push(new Route({ path: 'end?{bar}&{baz}&{foo}', exec: resolve }));
 		});
 		routes.reduce<{ append(route: Route<Context, Parameters>): void }>((parent, route) => {
-				parent.append(route);
-				return route;
-			}, router);
+			parent.append(route);
+			return route;
+		}, router);
 
 		router.start({ dispatchCurrent: false });
 		history.set('/root/FOO/deeper/BAR/foo/end?bar=bar&baz=baz1&baz=baz2&foo=f00');
 
 		return ready.then(() => {
-			assert.equal(router.link(routes[2], { foo: 'f00' }), '/root/f00/deeper/BAR/f00/end?bar=bar&baz=baz1&baz=baz2&foo=f00');
+			assert.equal(
+				router.link(routes[2], { foo: 'f00' }),
+				'/root/f00/deeper/BAR/f00/end?bar=bar&baz=baz1&baz=baz2&foo=f00'
+			);
 		});
 	});
 
@@ -1258,7 +1384,7 @@ suite('Router', () => {
 		history.set('/initial/foo');
 
 		return ready.then((links) => {
-			assert.deepEqual(links, [ '/initial/foo', '/initial/foo', '/foo' ]);
+			assert.deepEqual(links, ['/initial/foo', '/initial/foo', '/foo']);
 		});
 	});
 
@@ -1277,15 +1403,17 @@ suite('Router', () => {
 				return '/foo';
 			}
 		});
-		router.append([ initial, redirect ]);
+		router.append([initial, redirect]);
 
 		const ready = new Promise((resolve) => {
 			const route = new Route({
 				path: '/foo',
 				guard() {
-					resolve(new Promise((resolve) => {
-						resolve(router.link(initial));
-					}));
+					resolve(
+						new Promise((resolve) => {
+							resolve(router.link(initial));
+						})
+					);
 					return true;
 				}
 			});
@@ -1300,7 +1428,7 @@ suite('Router', () => {
 				throw new Error('Should have thrown');
 			})
 			.catch((err) => {
-				assert.equal(err.message, 'Cannot generate link, missing parameter \'foo\'');
+				assert.equal(err.message, "Cannot generate link, missing parameter 'foo'");
 			});
 	});
 
@@ -1322,9 +1450,11 @@ suite('Router', () => {
 			const route = new Route({
 				path: '/foo',
 				guard() {
-					resolve(new Promise((resolve) => {
-						resolve(router.link(initial));
-					}));
+					resolve(
+						new Promise((resolve) => {
+							resolve(router.link(initial));
+						})
+					);
 					return true;
 				}
 			});
@@ -1339,7 +1469,7 @@ suite('Router', () => {
 				throw new Error('Should have thrown');
 			})
 			.catch((err) => {
-				assert.equal(err.message, 'Cannot generate link, missing parameter \'foo\'');
+				assert.equal(err.message, "Cannot generate link, missing parameter 'foo'");
 			});
 	});
 
@@ -1355,15 +1485,17 @@ suite('Router', () => {
 			}
 		});
 		const unmanaged = new Route({ path: '/unmanaged' });
-		router.append([ initial, unmanaged ]);
+		router.append([initial, unmanaged]);
 
 		const ready = new Promise((resolve) => {
 			const route = new Route({
 				path: '/foo',
 				guard() {
-					resolve(new Promise((resolve) => {
-						resolve(router.link(initial));
-					}));
+					resolve(
+						new Promise((resolve) => {
+							resolve(router.link(initial));
+						})
+					);
 					return true;
 				}
 			});
@@ -1378,7 +1510,7 @@ suite('Router', () => {
 				throw new Error('Should have thrown');
 			})
 			.catch((err) => {
-				assert.equal(err.message, 'Cannot generate link, missing parameter \'foo\'');
+				assert.equal(err.message, "Cannot generate link, missing parameter 'foo'");
 			});
 	});
 
@@ -1471,9 +1603,7 @@ suite('Router', () => {
 		try {
 			router.link('bar');
 			assert.fail('Link should throw an error if outlet has not been registered');
-		}
-		catch (e) {
-		}
+		} catch (e) {}
 	});
 
 	suite('dispatch errors are emitted', () => {
@@ -1510,7 +1640,9 @@ suite('Router', () => {
 				},
 				history
 			});
-			router.on('error', (event: any) => { events.push(event); });
+			router.on('error', (event: any) => {
+				events.push(event);
+			});
 			dispatch = () => {
 				return new Promise((resolve) => {
 					router.dispatch(context, path).finally(resolve);
@@ -1520,90 +1652,108 @@ suite('Router', () => {
 
 		test('route selection throws', () => {
 			const error = new Error();
-			router.append(new Route({
-				path,
-				guard(): boolean {
-					throw error;
-				}
-			}));
+			router.append(
+				new Route({
+					path,
+					guard(): boolean {
+						throw error;
+					}
+				})
+			);
 			return verify(dispatch(), error);
 		});
 
 		test('route exec throws', () => {
 			const error = new Error();
-			router.append(new Route({
-				path,
-				exec() {
-					throw error;
-				}
-			}));
+			router.append(
+				new Route({
+					path,
+					exec() {
+						throw error;
+					}
+				})
+			);
 			return verify(dispatch(), error);
 		});
 
 		test('route fallback throws', () => {
 			const error = new Error();
-			router.append(new Route({
-				path: '/foo',
-				fallback() {
-					throw error;
-				}
-			}));
+			router.append(
+				new Route({
+					path: '/foo',
+					fallback() {
+						throw error;
+					}
+				})
+			);
 			return verify(dispatch(), error);
 		});
 
 		test('route index throws', () => {
 			const error = new Error();
-			router.append(new Route({
-				path,
-				index() {
-					throw error;
-				}
-			}));
+			router.append(
+				new Route({
+					path,
+					index() {
+						throw error;
+					}
+				})
+			);
 			return verify(dispatch(), error);
 		});
 
 		test('router fallback throws', () => {
 			const error = new Error();
-			fallback = () => { throw error; };
+			fallback = () => {
+				throw error;
+			};
 			return verify(dispatch(), error);
 		});
 
 		test('route exec returns a rejected thenable', () => {
 			const error = new Error();
-			router.append(new Route({
-				path,
-				exec() {
-					return Promise.reject(error);
-				}
-			}));
+			router.append(
+				new Route({
+					path,
+					exec() {
+						return Promise.reject(error);
+					}
+				})
+			);
 			return verify(dispatch(), error);
 		});
 
 		test('route fallback returns a rejected thenable', () => {
 			const error = new Error();
-			router.append(new Route({
-				path: '/foo',
-				fallback() {
-					return Promise.reject(error);
-				}
-			}));
+			router.append(
+				new Route({
+					path: '/foo',
+					fallback() {
+						return Promise.reject(error);
+					}
+				})
+			);
 			return verify(dispatch(), error);
 		});
 
 		test('route index returns a rejected thenable', () => {
 			const error = new Error();
-			router.append(new Route({
-				path,
-				index() {
-					return Promise.reject(error);
-				}
-			}));
+			router.append(
+				new Route({
+					path,
+					index() {
+						return Promise.reject(error);
+					}
+				})
+			);
 			return verify(dispatch(), error);
 		});
 
 		test('router fallback returns a rejected thenable', () => {
 			const error = new Error();
-			fallback = () => { return Promise.reject(error); };
+			fallback = () => {
+				return Promise.reject(error);
+			};
 			return verify(dispatch(), error);
 		});
 
@@ -1638,19 +1788,21 @@ suite('Router', () => {
 
 			router.start({ dispatchCurrent: false });
 			history.set('/to');
-			return promise.then((path) => {
-				// Allow the redirect to propagate through the dispatch promise chain before checking to see if the
-				// error was emitted.
-				return new Promise((resolve) => setTimeout(resolve, 10, path));
-			}).then((path) => {
-				assert.lengthOf(events, 1);
-				const [ evt ] = events;
-				assert.strictEqual(evt.context, context);
-				assert.instanceOf(evt.error, Error);
-				assert.equal(evt.error.message, 'More than 20 redirects, giving up');
-				assert.strictEqual(evt.path, path);
-				assert.strictEqual(evt.target, router);
-			});
+			return promise
+				.then((path) => {
+					// Allow the redirect to propagate through the dispatch promise chain before checking to see if the
+					// error was emitted.
+					return new Promise((resolve) => setTimeout(resolve, 10, path));
+				})
+				.then((path) => {
+					assert.lengthOf(events, 1);
+					const [evt] = events;
+					assert.strictEqual(evt.context, context);
+					assert.instanceOf(evt.error, Error);
+					assert.equal(evt.error.message, 'More than 20 redirects, giving up');
+					assert.strictEqual(evt.path, path);
+					assert.strictEqual(evt.target, router);
+				});
 		});
 	});
 
@@ -1665,12 +1817,14 @@ suite('Router', () => {
 				assert.isTrue(context.refined);
 			}
 		});
-		router.append(new Route<Refined, any>({
-			path: '/foo',
-			exec({ context }) {
-				assert.isTrue(context.refined);
-			}
-		}));
+		router.append(
+			new Route<Refined, any>({
+				path: '/foo',
+				exec({ context }) {
+					assert.isTrue(context.refined);
+				}
+			})
+		);
 		router.dispatch({ refined: true }, '/foo');
 		router.dispatch({ refined: true }, '/bar');
 	});

--- a/tests/unit/RouterInjector.ts
+++ b/tests/unit/RouterInjector.ts
@@ -8,11 +8,10 @@ import { MemoryHistory } from '../../src/history/MemoryHistory';
 const history = new MemoryHistory();
 
 suite('RouterInjector', () => {
-
 	test('registerRouterInjector', () => {
 		let invalidateCalled = false;
 		const registry = new Registry();
-		const router = registerRouterInjector([ { path: 'path' } ], registry, { history });
+		const router = registerRouterInjector([{ path: 'path' }], registry, { history });
 		const injector = registry.getInjector(routerKey) as Injector;
 		assert.isNotNull(injector);
 		assert.strictEqual(injector.get(), router);
@@ -26,7 +25,7 @@ suite('RouterInjector', () => {
 	test('registerRouterInjector with custom key', () => {
 		let invalidateCalled = false;
 		const registry = new Registry();
-		const router = registerRouterInjector([ { path: 'path' } ], registry, { history, key: 'custom-key' });
+		const router = registerRouterInjector([{ path: 'path' }], registry, { history, key: 'custom-key' });
 		const injector = registry.getInjector('custom-key') as Injector;
 		assert.isNotNull(injector);
 		const registeredRouter = injector.get();
@@ -40,9 +39,13 @@ suite('RouterInjector', () => {
 
 	test('throws error if a second router is registered for the same key', () => {
 		const registry = new Registry();
-		registerRouterInjector([ { path: 'path' } ], registry, { history });
-		assert.throws(() => {
-			registerRouterInjector([ { path: 'path' } ], registry, { history });
-		}, Error, 'Router has already been defined');
+		registerRouterInjector([{ path: 'path' }], registry, { history });
+		assert.throws(
+			() => {
+				registerRouterInjector([{ path: 'path' }], registry, { history });
+			},
+			Error,
+			'Router has already been defined'
+		);
 	});
 });

--- a/tests/unit/history/HashHistory.ts
+++ b/tests/unit/history/HashHistory.ts
@@ -10,16 +10,16 @@ suite('HashHistory', () => {
 	// Mask the globals so tests are forced to explicitly reference the
 	// correct window.
 	/* tslint:disable */
-	const location: void = <any> null;
+	const location: void = <any>null;
 	/* tslint:enable */
 
 	let sandbox: HTMLIFrameElement;
-	beforeEach(function () {
+	beforeEach(function() {
 		sandbox = document.createElement('iframe');
 		sandbox.src = '/tests/support/sandbox.html';
 		document.body.appendChild(sandbox);
-		return new Promise<void>(resolve => {
-			sandbox.addEventListener('load', function () {
+		return new Promise<void>((resolve) => {
+			sandbox.addEventListener('load', function() {
 				resolve();
 			});
 		});
@@ -27,7 +27,7 @@ suite('HashHistory', () => {
 
 	afterEach(() => {
 		document.body.removeChild(sandbox);
-		sandbox = <any> null;
+		sandbox = <any>null;
 	});
 
 	test('initializes current path to current location', () => {
@@ -62,11 +62,10 @@ suite('HashHistory', () => {
 		});
 		history.set('/foo');
 
-		return new Promise((resolve) => setTimeout(resolve, 500))
-			.then(() => {
-				assert.lengthOf(emittedValues, 1);
-				assert.equal(emittedValues[0], '/foo');
-			});
+		return new Promise((resolve) => setTimeout(resolve, 500)).then(() => {
+			assert.lengthOf(emittedValues, 1);
+			assert.equal(emittedValues[0], '/foo');
+		});
 	});
 
 	test('does not emit change if path is set to the current value', () => {
@@ -106,11 +105,10 @@ suite('HashHistory', () => {
 		});
 		history.replace('/foo');
 
-		return new Promise((resolve) => setTimeout(resolve, 500))
-			.then(() => {
-				assert.lengthOf(emittedValues, 1);
-				assert.equal(emittedValues[0], '/foo');
-			});
+		return new Promise((resolve) => setTimeout(resolve, 500)).then(() => {
+			assert.lengthOf(emittedValues, 1);
+			assert.equal(emittedValues[0], '/foo');
+		});
 	});
 
 	test('does not emit change if path is replaced with the current value', () => {
@@ -141,7 +139,7 @@ suite('HashHistory', () => {
 			const createFauxWindow = class extends Evented<{}> {
 				location = contentWindowLocation;
 			};
-			window = <any> new createFauxWindow();
+			window = <any>new createFauxWindow();
 		});
 
 		test('handles hashchange', () => {
@@ -163,7 +161,7 @@ suite('HashHistory', () => {
 			const history = new HashHistory({ window });
 			assert.equal(history.current, '');
 
-			return history.destroy().then(function () {
+			return history.destroy().then(function() {
 				sandbox.contentWindow.location.hash = '#/foo';
 				emit(window, { type: 'hashchange' });
 

--- a/tests/unit/history/MemoryHistory.ts
+++ b/tests/unit/history/MemoryHistory.ts
@@ -9,7 +9,7 @@ suite('MemoryHistory', () => {
 	});
 
 	test('can create history with initial path', () => {
-		assert.equal(new MemoryHistory({ path: '/initial'}).current, '/initial');
+		assert.equal(new MemoryHistory({ path: '/initial' }).current, '/initial');
 	});
 
 	test('does not prefix the path', () => {

--- a/tests/unit/history/StateHistory.ts
+++ b/tests/unit/history/StateHistory.ts
@@ -10,17 +10,17 @@ suite('StateHistory', () => {
 	// Mask the globals so tests are forced to explicitly reference the
 	// correct window.
 	/* tslint:disable */
-	const history: void = <any> null;
-	const location: void = <any> null;
+	const history: void = <any>null;
+	const location: void = <any>null;
 	/* tslint:enable */
 
 	let sandbox: HTMLIFrameElement;
-	beforeEach(function () {
+	beforeEach(function() {
 		sandbox = document.createElement('iframe');
 		sandbox.src = '/tests/support/sandbox.html';
 		document.body.appendChild(sandbox);
-		return new Promise<void>(resolve => {
-			sandbox.addEventListener('load', function () {
+		return new Promise<void>((resolve) => {
+			sandbox.addEventListener('load', function() {
 				resolve();
 			});
 		});
@@ -28,7 +28,7 @@ suite('StateHistory', () => {
 
 	afterEach(() => {
 		document.body.removeChild(sandbox);
-		sandbox = <any> null;
+		sandbox = <any>null;
 	});
 
 	test('initializes current path to current location', () => {
@@ -127,15 +127,23 @@ suite('StateHistory', () => {
 
 	suite('with base', () => {
 		test('throws if base contains #', () => {
-			assert.throws(() => {
-				new StateHistory({ base: '/foo#bar', window });
-			}, TypeError, 'base must not contain \'#\'');
+			assert.throws(
+				() => {
+					new StateHistory({ base: '/foo#bar', window });
+				},
+				TypeError,
+				"base must not contain '#'"
+			);
 		});
 
 		test('throws if base contains ?', () => {
-			assert.throws(() => {
-				new StateHistory({ base: '/foo?bar', window });
-			}, TypeError, 'base must not contain \'?\'');
+			assert.throws(
+				() => {
+					new StateHistory({ base: '/foo?bar', window });
+				},
+				TypeError,
+				"base must not contain '?'"
+			);
 		});
 
 		test('initializes current path, taking out the base, with trailing slash', () => {
@@ -148,7 +156,7 @@ suite('StateHistory', () => {
 			assert.equal(new StateHistory({ base: '/foo', window: sandbox.contentWindow }).current, '/bar?baz');
 		});
 
-		test('initializes current path to / if it\'s not a base suffix', () => {
+		test("initializes current path to / if it's not a base suffix", () => {
 			sandbox.contentWindow.history.pushState({}, '', '/foo/bar?baz');
 			assert.equal(new StateHistory({ base: '/thud/', window: sandbox.contentWindow }).current, '/');
 		});
@@ -219,7 +227,7 @@ suite('StateHistory', () => {
 				location = contentWindowLocation;
 				history = contentWindowHistory;
 			};
-			window = <any> new createFauxWindow();
+			window = <any>new createFauxWindow();
 		});
 
 		test('handles popstate', () => {

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -9,7 +9,6 @@ import MemoryHistory from '../../src/history/MemoryHistory';
 import StateHistory from '../../src/history/StateHistory';
 
 suite('main', () => {
-
 	test('#createRoute is the same as @dojo/routing/createRoute', () => {
 		assert.strictEqual(main.Route, Route);
 	});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
 		],
 		"module": "umd",
 		"moduleResolution": "node",
+		"noUnusedLocals": true,
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,7 @@
 {
+	"rulesDirectory": ["tslint-plugin-prettier"],
 	"rules": {
+		"prettier": true,
 		"align": false,
 		"ban": [],
 		"class-name": true,
@@ -30,15 +32,12 @@
 		"no-switch-case-fall-through": false,
 		"no-trailing-whitespace": true,
 		"no-unused-expression": false,
-		"no-unused-variable": true,
 		"no-use-before-declare": false,
 		"no-var-keyword": true,
 		"no-var-requires": false,
 		"object-literal-sort-keys": false,
 		"one-line": [ true, "check-open-brace", "check-whitespace" ],
-		"quotemark": [ true, "single" ],
 		"radix": true,
-		"semicolon": [ true, "always" ],
  		"trailing-comma": [ true, {
 			"multiline": "never",
 			"singleline": "never"
@@ -58,8 +57,6 @@
 			"property-declaration": "onespace",
 			"variable-declaration": "onespace"
 		} ],
-		"use-strict": false,
-		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords", "allow-pascal-case" ],
-		"whitespace": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
+		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords", "allow-pascal-case" ]
 	}
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds support for `Prettier` to for code style rules and formatting. Include precommit hook that runs prettier on all `.ts` files and an npm script that runs prettier against the codebase.

Related to https://github.com/dojo/meta/issues/206
