### PR TITLE
Fix the method argument to the route injector

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ import MemoryHistory from './history/MemoryHistory';
 const customRegistry = new WidgetRegistry();
 const history = new MemoryHistory();
 
-const router = registerRouterInjector(config, customRegistry, history, 'custom-router-key');
+const router = registerRouterInjector(config, customRegistry, { history }, 'custom-router-key');
 ```
 
 The final thing to do is call `router.start()` to start the `router` instance.


### PR DESCRIPTION
**Type:** bug

**Description:**

This caught me out! We should pass an object when specifying the history, but the docs didn't show this bit exactly!
