### PR TITLE
Use QueuingEvented to ensure that the first event is fired for listeners after the router instantiation

### DIFF
--- a/src/Router.ts
+++ b/src/Router.ts
@@ -1,4 +1,4 @@
-import { Evented } from '@dojo/core/Evented';
+import QueuingEvented from '@dojo/core/QueuingEvented';
 import {
 	RouteConfig,
 	History,
@@ -13,7 +13,7 @@ import { HashHistory } from './history/HashHistory';
 
 const PARAM = Symbol('routing param');
 
-export class Router extends Evented implements RouterInterface {
+export class Router extends QueuingEvented implements RouterInterface {
 	private _routes: Route[] = [];
 	private _outletMap: { [index: string]: Route } = Object.create(null);
 	private _matchedOutlets: { [index: string]: OutletContext } = Object.create(null);

--- a/tests/unit/Router.ts
+++ b/tests/unit/Router.ts
@@ -314,4 +314,13 @@ describe('Router', () => {
 		const link = router.link('unknown');
 		assert.isUndefined(link);
 	});
+
+	it('Queues the first event for the first registered listener', () => {
+		let initialNavEvent = false;
+		const router = new Router(routeConfigDefaultRoute, { HistoryManager });
+		router.on('nav', () => {
+			initialNavEvent = true;
+		});
+		assert.isTrue(initialNavEvent);
+	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

The first route event is missed for listeners, using `QueuingEvented` means that the event is still fired for the first registered listener.

Other possible solutions would be to add an option on construction for an event listener or to add a `start` function that needs to be called once setup is completed.

Resolves #129
