### PR TITLE
Type the 'nav' event and only emit on match

### DIFF
--- a/src/Router.ts
+++ b/src/Router.ts
@@ -10,10 +10,16 @@ import {
 	RouterOptions
 } from './interfaces';
 import { HashHistory } from './history/HashHistory';
+import { EventObject } from '@dojo/core/interfaces';
 
 const PARAM = Symbol('routing param');
 
-export class Router extends QueuingEvented implements RouterInterface {
+export interface NavEvent extends EventObject<string> {
+	outlet: string;
+	context: OutletContext;
+}
+
+export class Router extends QueuingEvented<{ nav: NavEvent }> implements RouterInterface {
 	private _routes: Route[] = [];
 	private _outletMap: { [index: string]: Route } = Object.create(null);
 	private _matchedOutlets: { [index: string]: OutletContext } = Object.create(null);
@@ -266,7 +272,9 @@ export class Router extends QueuingEvented implements RouterInterface {
 				type: 'error'
 			};
 		}
-		this.emit({ type: 'nav', outlet: matchedOutlet, context: matchedOutletContext });
+		if (matchedOutlet && matchedOutletContext) {
+			this.emit({ type: 'nav', outlet: matchedOutlet, context: matchedOutletContext });
+		}
 	};
 }
 

--- a/tests/unit/Router.ts
+++ b/tests/unit/Router.ts
@@ -318,7 +318,16 @@ describe('Router', () => {
 	it('Queues the first event for the first registered listener', () => {
 		let initialNavEvent = false;
 		const router = new Router(routeConfigDefaultRoute, { HistoryManager });
-		router.on('nav', () => {
+		router.on('nav', (event) => {
+			assert.strictEqual(event.type, 'nav');
+			assert.strictEqual(event.outlet, 'foo');
+			assert.deepEqual(event.context, {
+				queryParams: {},
+				params: { bar: 'defaultBar' },
+				type: 'index',
+				onEnter: undefined,
+				onExit: undefined
+			});
 			initialNavEvent = true;
 		});
 		assert.isTrue(initialNavEvent);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Add type for the `nav` event and only emit when a route is matched

Resolves #132 
